### PR TITLE
fix(e2e): list-error 断言不再假设 admin 在默认第一页

### DIFF
--- a/apps/web/e2e/AGENTS.md
+++ b/apps/web/e2e/AGENTS.md
@@ -209,6 +209,28 @@ await expect(page.locator('[data-visible="true"] table tbody tr').first()).toBeV
 `beforeAll`/`afterAll` 里能用）和 `loginPageAs(page, username, password)`
 （`authedPage` 写死了 admin，而这份测试要的正是「换个账号看见的不一样」）。
 
+### 🔴 跨文件并行会污染默认分页假设——`serial` 只护得住同一个 describe
+
+`data-permission.spec.ts` 的 `beforeAll`/`afterAll` 之间会有 19 个临时账号常驻
+`fba_test`（见上一节）。`test.describe.configure({ mode: "serial" })` 只保证
+**这个 describe 内部**的用例不并行、不撞唯一约束——**挡不住别的 spec 文件**
+在同一个时间窗口被分到另一个 worker 并行跑（`playwright.config.ts` 是
+`fullyParallel: true`），而两者共用同一个 `fba_test`。
+
+`list-error.spec.ts` 原来断言「502 重试后表里能看到 `admin@example.com`」，
+默认没有筛选、看的是第一页。这个断言隐含了「用户总数不多，admin 一定在
+第一页」——本地单独跑这一个文件时成立，但在 CI 上和 `data-permission.spec.ts`
+撞到同一个并行窗口就会破：总数从种子的 10 涨到 29，admin 被挤到第二页，
+断言失败，而失败信息看起来和这条测试本身毫无关系（一串陌生的
+`dp_d_xxx@e2e.example.com` 账号）。**实测复现**：2026-08-25 给 `main` 上线分支
+保护、E2E 第一次被设成必过的 required check 时当场撞见。
+
+修法是断言改成不依赖总数/分页/具体某个用户——`table.locator('[data-slot=
+"table-body"] [data-slot="table-row"]').first()` 只要表体真的渲出行就算数。
+**教训**：任何断言默认视图（不筛选、不指定页）里「某条具体数据看不看得见」的写法，
+在共享数据库 + 全并行的 E2E 里都是定时炸弹——数据会被同一时间窗口里跑的
+别的 spec 文件影响，且它们之间没有任何协作关系。
+
 ### 现在测了什么 / 没测什么
 
 种子用例：登录（表单校验 + 验证码关闭路径）、部门 CRUD 闭环（含 409 冲突

--- a/apps/web/e2e/tests/list-error.spec.ts
+++ b/apps/web/e2e/tests/list-error.spec.ts
@@ -38,8 +38,13 @@ test.describe("列表页取数失败", () => {
     fail = false
     await table.getByTestId("query-error-retry").click()
     await expect(error).toBeHidden()
-    // 用户表没挂行级 testid，用「表里出现了真实数据」来断言重取成功
-    await expect(table).toContainText("admin@example.com")
+    // 用户表没挂行级 testid，用「表体真的渲出行」断言重取成功。
+    // ⚠️ 不能断言具体某个用户（曾经断言 admin@example.com 在默认第一页）——
+    // data-permission.spec.ts 的 beforeAll/afterAll 之间会有 19 个临时账号
+    // 并发存在于 fba_test，`fullyParallel` 下这条测试和它同时跑，总数一多
+    // admin 就被挤到第二页，断言变成随并行调度抖动的假失败（实测复现，见
+    // e2e/CLAUDE.md「跨文件并行会污染默认分页假设」）
+    await expect(table.locator('[data-slot="table-body"] [data-slot="table-row"]').first()).toBeVisible()
   })
 
   test("部门管理：502 显示错误块，不是「没有匹配的部门」", async ({ authedPage: page }) => {


### PR DESCRIPTION
第一个 PR（#18）跑分支保护实测时，E2E 挂了——不是我改动的问题，是暴露了一个既有的跨文件测试隔离缺口：

`data-permission.spec.ts` 的 `beforeAll`/`afterAll` 之间会有 19 个临时账号常驻 `fba_test`。`fullyParallel: true` 下，`list-error.spec.ts` 可能被分到另一个 worker 和它同时跑，总数从种子的 10 涨到 29，把 admin 挤到第二页——而 `list-error.spec.ts` 原来的断言默认看第一页有没有 `admin@example.com`。本地单独跑这个文件永远不会暴露，只有撞上那个并行窗口才会假失败。

改法：断言换成 `[data-slot=table-row]` 只要表体真的渲出行就算数，不再依赖总数/分页/具体某个用户。补了 `e2e/AGENTS.md` 一条记录这个坑。

这个 PR 合完之后 PR #18（分支保护文档）应该就能正常通过 required checks 了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)