### PR TITLE
docs: README 加在线演示入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 **FastAPI + React 19 + shadcn/ui 中后台底座** —— 权限细到按钮和数据行，
 多页签切走真的保状态，原生跑 SQL Server。**238 条自动化测试全打真实依赖，不 mock。**
 
+> 🚀 **在线演示 / Live demo：** https://fra.wubunan.com/sign-in
+> 账号 `admin` / 密码 `123456` —— 公开演示实例，任何人都能登录，数据会被访客改动/清空，
+> 请勿存放真实信息。/ Public demo instance, anyone can log in; data may be altered or wiped
+> by other visitors — do not store real information here.
+
 <table>
 <tr>
 <td width="50%"><img src="./docs/screenshots/dashboard.png" alt="仪表盘"></td>


### PR DESCRIPTION
## 做了什么
`fra.wubunan.com` 的反代 + HTTPS 证书配好之后，在 README 顶部加了一条「在线演示」
入口（`admin` / `123456`），方便访客直接登录试用。

同时明确标注这是公开实例，数据可能被其他访客改动/清空，别存真实信息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)