### PR TITLE
fix(deploy): celery worker/beat 的健康检查一直是假阴性

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -172,8 +172,13 @@ services:
       - fba_upload:/app/backend/upload
       - fba_upload_public:/app/backend/upload-public
       - fba_log_worker:/app/backend/log
+    # 🔴 `inspect` 默认超时 1s，实测这个 AsyncIOPool 走一趟 broker 往返要 ~2s——
+    # docker 的 timeout: 15s 管的是「命令跑多久算超时」，挡不住 celery 自己
+    # 内部先喊出 `No nodes replied within time constraint`（exit 69）退出。
+    # 手动加 `--timeout=10` 之后单次 ping 稳定在 2s 左右通过。生产上部署过一次
+    # 才发现——worker 一直在正常处理任务，健康检查却一直报 unhealthy。
     healthcheck:
-      test: ["CMD", "celery", "-A", "backend.app.task.celery", "inspect", "ping", "-d", "celery@$${HOSTNAME}"]
+      test: ["CMD", "celery", "-A", "backend.app.task.celery", "inspect", "ping", "-d", "celery@$${HOSTNAME}", "--timeout=10"]
       interval: 30s
       timeout: 15s
       retries: 3
@@ -199,8 +204,12 @@ services:
     volumes:
       - ./apps/api/deploy/backend/docker-compose/.env.server:/app/backend/.env:ro
       - fba_log_beat:/app/backend/log
+    # 🔴 镜像基于 Debian slim，没装 procps——`pgrep` 是「命令不存在」（exit 127），
+    # 不是「没找到进程」，健康检查因此永远失败，即便 beat 跑得好好的。
+    # beat 进程就是容器的 PID 1（没有 shell 包一层），直接读 /proc/1/cmdline，
+    # 不用依赖额外装的工具
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' > /dev/null || exit 1"]
+      test: ["CMD-SHELL", "grep -q beat /proc/1/cmdline"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
更新生产服务器时顺手发现的——查了容器状态,worker/beat 一直显示 unhealthy,但日志显示两者都在正常工作(worker ready、beat 载入了 2 条调度)。

`docker inspect` 的健康检查历史一挖就看出来两个都是假阴性:

- **worker**: `No nodes replied within time constraint`(exit 69)——celery inspect 默认超时 1s,这个 AsyncIOPool 走一趟 broker 往返实测要 ~2s。加 `--timeout=10`
- **beat**: `/bin/sh: 1: pgrep: not found`(exit 127)——镜像是 Debian slim,没装 procps。beat 是容器 PID 1,改成读 `/proc/1/cmdline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)