### PR TITLE
fix(seed): 公开演示数据补齐 mysql/postgresql

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -550,6 +550,21 @@ test_init_handles_every_seeded_account` 硬编码断言 `cli.py: _set_admin_pass
 - 种子 SQL 文件里**不能加解释性的独立注释块**（`--` 开头的裸注释会被
   `sql_parser.py` 的白名单校验直接判成非法语句，见「跑测试」一节踩过的坑），
   上面这些"为什么"只能写在这里，不能写进 SQL 文件本身
+- 🔴 **三个方言各自一份文件，靠人工保持同步——没有任何机器校验三份内容对得上。**
+  这批"公开演示"数据最早只加进了 `sql/sqlserver/`，`mysql/`、`postgresql/`
+  两份原地放了半年多还是最初那个 1 部门 + 1 角色 + 2 账号的最小种子，没人发现，
+  因为两条守卫（`test_seeded_password_hashes_cover_every_seeded_account` /
+  `test_model_matches_migrations`）都不比较"三份种子内容是否一致"，只比较
+  "种子里出现的 hash 在不在白名单里"——三份缺两份一样能全绿。
+  这台生产机跑的是 PostgreSQL，公开演示上线之后组织架构一直是那个最小种子，
+  直到有人发现"看着不像回事"才补的。2026-08-26 已把 `mysql`/`postgresql`
+  两份补齐到跟 `sqlserver` 同样的内容（部门/角色/账号语义一致，
+  ID 各方言自己独立一套——`mysql` 恰好和 `sqlserver` 本来就共用同一批 ID，
+  直接照抄；`postgresql` 的基础种子（admin/test/部门/角色）本来就是另一套 ID，
+  改名复用 + 新增部分另起一段 `4000000000000000xxx` 区间）。
+  **以后改这批演示数据，三份 `init_snowflake_test_data.sql` 一起改，
+  改完跑一遍 `test_seeded_password_hashes_cover_every_seeded_account`
+  只能保证 hash 有登记，保证不了三份"部门/角色长得一样"，这条得靠人记。**
 
 ### 有测试的部分 / 没测试的部分
 

--- a/apps/api/backend/sql/mysql/init_snowflake_test_data.sql
+++ b/apps/api/backend/sql/mysql/init_snowflake_test_data.sql
@@ -1,5 +1,12 @@
 insert into sys_dept (id, code, name, sort, leader, phone, email, status, deleted, parent_id, created_time, updated_time)
-values (2048601258595581952, 'TEST', '测试', 0, null, null, null, 1, 0, null, now(), null);
+values
+(2048601258595581952, 'HQ', '总部', 0, null, null, null, 1, 0, null, now(), null),
+(3000000000000000001, 'TECH', '技术中心', 1, '张伟', null, null, 1, 0, 2048601258595581952, now(), null),
+(3000000000000000002, 'TECH_BE', '后端组', 1, '刘洋', null, null, 1, 0, 3000000000000000001, now(), null),
+(3000000000000000003, 'TECH_FE', '前端组', 2, '陈静', null, null, 1, 0, 3000000000000000001, now(), null),
+(3000000000000000004, 'PRODUCT', '产品设计中心', 2, '李娜', null, null, 1, 0, 2048601258595581952, now(), null),
+(3000000000000000005, 'MARKETING', '市场运营中心', 3, '赵磊', null, null, 1, 0, 2048601258595581952, now(), null),
+(3000000000000000006, 'FINANCE', '财务人事中心', 4, '王芳', null, null, 1, 0, 2048601258595581952, now(), null);
 
 insert into sys_menu (id, title, name, path, sort, icon, type, perms, status, display, link, remark, parent_id, created_time, updated_time)
 values
@@ -64,22 +71,56 @@ values
 (2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', 0, 1, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null);
 
 insert into sys_role (id, code, name, status, is_filter_scopes, remark, created_time, updated_time)
-values (2048601263515500544, 'TEST', '测试', 1, true, null, now(), null);
+values
+(2048601263515500544, 'STAFF', '普通员工', 1, true, '基础角色，只看仪表盘和个人中心', now(), null),
+(3000000000000000011, 'MANAGER', '部门经理', 1, true, '演示部门及以下数据权限用——能看本部门和下级部门的用户/部门列表', now(), null),
+(3000000000000000012, 'FINANCE_STAFF', '财务专员', 1, true, '演示本部门数据权限用', now(), null),
+(3000000000000000013, 'VIEWER', '只读访客', 1, true, '演示仅本人数据权限用——范围最窄的角色', now(), null);
 
 insert into sys_role_menu (id, role_id, menu_id)
 values
 (2048601263578415104, 2048601263515500544, 2049629108245233664),
-(2048601263775547392, 2048601263515500544, 2049629108253622282);
+(2048601263775547392, 2048601263515500544, 2049629108253622282),
+(3000000000000000021, 3000000000000000011, 2049629108245233664),
+(3000000000000000022, 3000000000000000011, 2049629108253622282),
+(3000000000000000023, 3000000000000000011, 2049629108245233668),
+(3000000000000000024, 3000000000000000011, 2049629108245233672),
+(3000000000000000025, 3000000000000000012, 2049629108245233664),
+(3000000000000000026, 3000000000000000012, 2049629108253622282),
+(3000000000000000027, 3000000000000000013, 2049629108245233664),
+(3000000000000000028, 3000000000000000013, 2049629108253622282);
+
+insert into sys_role_data_scope (id, role_id, data_scope_id)
+values
+(3000000000000000031, 3000000000000000011, 2048601263968485376),
+(3000000000000000032, 3000000000000000012, 2048601263901376512),
+(3000000000000000033, 3000000000000000013, 2048601263968485377);
 
 insert into sys_user (id, uuid, username, nickname, password, salt, email, status, is_superuser, is_staff, is_multi_login, avatar, timezone, phone, join_time, last_login_time, last_password_changed_time, dept_id, created_time, updated_time)
 values
-(2048601263834267648, uuid(), 'admin', '用户88888', '$2b$12$8y2eNucX19VjmZ3tYhBLcOsBwy9w1IjBQE4SSqwMDL5bGQVp2wqS.', unhex('24326224313224387932654E7563583139566A6D5A33745968424C634F'), 'admin@example.com', 1, true, true, true, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601258595581952, now(), null),
-(2049946297615646720, uuid(), 'test', '用户66666', '$2b$12$BMiXsNQAgTx7aNc7kVgnwedXGyUxPEHRnJMFbiikbqHgVoT3y14Za', unhex('24326224313224424D6958734E514167547837614E63376B56676E7765'), 'test@example.com', 1, false, false, false, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601258595581952, now(), null);
+(2048601263834267648, uuid(), 'admin', '系统管理员', '$2b$12$8y2eNucX19VjmZ3tYhBLcOsBwy9w1IjBQE4SSqwMDL5bGQVp2wqS.', unhex('24326224313224387932654E7563583139566A6D5A33745968424C634F'), 'admin@example.com', 1, true, true, true, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601258595581952, now(), null),
+(2049946297615646720, uuid(), 'test', '李静', '$2b$12$BMiXsNQAgTx7aNc7kVgnwedXGyUxPEHRnJMFbiikbqHgVoT3y14Za', unhex('24326224313224424D6958734E514167547837614E63376B56676E7765'), 'test@example.com', 1, false, false, false, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601258595581952, now(), null),
+(3000000000000000041, uuid(), 'zhangwei', '张伟', '$2b$12$Pnvhzs0e1pJ8qyvB9Kkv1em/IpT.46XKEfPqoIoLR2ly8RVCVEcLS', unhex('506E76687A73306531704A3871797642394B6B763165'), 'zhangwei@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000001, now(), null),
+(3000000000000000042, uuid(), 'lina', '李娜', '$2b$12$7xeTTK8azV4xXUGpZY7kBef7pfDj6ilVE1Pkt6VReNH5xd8kCgVEi', unhex('37786554544B38617A563478585547705A59376B4265'), 'lina@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000004, now(), null),
+(3000000000000000043, uuid(), 'wangfang', '王芳', '$2b$12$rCfJ7pCZp/CsGhfbBcU9YuXzfYb8xl8Xm7AqSG5u0fiyoetNGInQ.', unhex('7243664A3770435A702F437347686662426355395975'), 'wangfang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000006, now(), null),
+(3000000000000000044, uuid(), 'liuyang', '刘洋', '$2b$12$z958muAw9wAclhvxw6tzROV8vIR2COsPdakXXv4d7QF7litw1Wdl6', unhex('7A3935386D754177397741636C6876787736747A524F'), 'liuyang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000002, now(), null),
+(3000000000000000045, uuid(), 'chenjing', '陈静', '$2b$12$wqmNVS86davwAaQWMA/kL.P1nU4CV3HAeLcq0XdMBRSbsY5N/KIoa', unhex('77716D4E5653383664617677416151574D412F6B4C2E'), 'chenjing@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000003, now(), null),
+(3000000000000000046, uuid(), 'zhaolei', '赵磊', '$2b$12$aQ0gVSkO.pJi7iWXvx1UBujb9vnumYbTjhmoYlPgau/eo.t9oD0Pi', unhex('6151306756536B4F2E704A6937695758767831554275'), 'zhaolei@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000005, now(), null),
+(3000000000000000047, uuid(), 'sunqiang', '孙强', '$2b$12$T06KtP5UZLuKbgEccyCBa.9bW9nIysTPn0WyX5Bc/B3cxwLvxW62W', unhex('5430364B745035555A4C754B6267456363794342612E'), 'sunqiang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 3000000000000000005, now(), null),
+(3000000000000000048, uuid(), 'zhoumin', '周敏', '$2b$12$PUJ3wLeG0VSqQoKdvu/NKuYcnyF4AgfZDES2UoktE3uAdTeergGB.', unhex('50554A33774C654730565371516F4B6476752F4E4B75'), 'zhoumin@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 2048601258595581952, now(), null);
 
 insert into sys_user_role (id, user_id, role_id)
 values
 (2048601263838461952, 2048601263834267648, 2048601263515500544),
-(2049946493732913152, 2049946297615646720, 2048601263515500544);
+(2049946493732913152, 2049946297615646720, 2048601263515500544),
+(3000000000000000051, 3000000000000000041, 3000000000000000011),
+(3000000000000000052, 3000000000000000042, 2048601263515500544),
+(3000000000000000053, 3000000000000000043, 3000000000000000012),
+(3000000000000000054, 3000000000000000044, 2048601263515500544),
+(3000000000000000055, 3000000000000000045, 2048601263515500544),
+(3000000000000000056, 3000000000000000046, 3000000000000000011),
+(3000000000000000057, 3000000000000000047, 2048601263515500544),
+(3000000000000000058, 3000000000000000048, 3000000000000000013);
 
 insert into sys_data_scope (id, name, status, created_time, updated_time)
 values
@@ -92,8 +133,8 @@ values
 insert into sys_data_rule (id, name, model, `column`, operator, expression, `value`, created_time, updated_time)
 values
 (2048601264035594240, '部门 ID 等于当前用户部门', '__ALL__', '__dept_id__', 0, 0, '${dept_id}', now(), null),
-(2048601264102703104, '部门编码等于 TEST', 'Dept', 'code', 1, 0, 'TEST', now(), null),
-(2048601264102703105, '父部门 ID 等于测试部门 ID', 'Dept', 'parent_id', 0, 0, '2048601258595581952', now(), null),
+(2048601264102703104, '部门编码等于 HQ', 'Dept', 'code', 1, 0, 'HQ', now(), null),
+(2048601264102703105, '父部门 ID 等于总部部门 ID', 'Dept', 'parent_id', 0, 0, '2048601258595581952', now(), null),
 (2048601264102703106, '创建者等于当前用户', '__ALL__', '__created_by__', 0, 0, '${user_id}', now(), null),
 (2048601264102703107, '全模型部门 ID 等于当前用户部门', '__ALL__', '__dept_id__', 0, 0, '${dept_id}', now(), null),
 (2048601264102703109, '用户非超级管理员', 'User', 'is_superuser', 0, 1, '1', now(), null);

--- a/apps/api/backend/sql/postgresql/init_snowflake_test_data.sql
+++ b/apps/api/backend/sql/postgresql/init_snowflake_test_data.sql
@@ -1,5 +1,12 @@
 insert into sys_dept (id, code, name, sort, leader, phone, email, status, deleted, parent_id, created_time, updated_time)
-values (2048601264366944256, 'TEST', '测试', 0, null, null, null, 1, 0, null, now(), null);
+values
+(2048601264366944256, 'HQ', '总部', 0, null, null, null, 1, 0, null, now(), null),
+(4000000000000000001, 'TECH', '技术中心', 1, '张伟', null, null, 1, 0, 2048601264366944256, now(), null),
+(4000000000000000002, 'TECH_BE', '后端组', 1, '刘洋', null, null, 1, 0, 4000000000000000001, now(), null),
+(4000000000000000003, 'TECH_FE', '前端组', 2, '陈静', null, null, 1, 0, 4000000000000000001, now(), null),
+(4000000000000000004, 'PRODUCT', '产品设计中心', 2, '李娜', null, null, 1, 0, 2048601264366944256, now(), null),
+(4000000000000000005, 'MARKETING', '市场运营中心', 3, '赵磊', null, null, 1, 0, 2048601264366944256, now(), null),
+(4000000000000000006, 'FINANCE', '财务人事中心', 4, '王芳', null, null, 1, 0, 2048601264366944256, now(), null);
 
 insert into sys_menu (id, title, name, path, sort, icon, type, perms, status, display, link, remark, parent_id, created_time, updated_time)
 values
@@ -64,22 +71,56 @@ values
 (2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', false, true, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null);
 
 insert into sys_role (id, code, name, status, is_filter_scopes, remark, created_time, updated_time)
-values (2048601269345583104, 'TEST', '测试', 1, true, null, now(), null);
+values
+(2048601269345583104, 'STAFF', '普通员工', 1, true, '基础角色，只看仪表盘和个人中心', now(), null),
+(4000000000000000011, 'MANAGER', '部门经理', 1, true, '演示部门及以下数据权限用——能看本部门和下级部门的用户/部门列表', now(), null),
+(4000000000000000012, 'FINANCE_STAFF', '财务专员', 1, true, '演示本部门数据权限用', now(), null),
+(4000000000000000013, 'VIEWER', '只读访客', 1, true, '演示仅本人数据权限用——范围最窄的角色', now(), null);
 
 insert into sys_role_menu (id, role_id, menu_id)
 values
 (2048601269412691968, 2048601269345583104, 2049629108245233664),
-(2048601269609824256, 2048601269345583104, 2049629108253622282);
+(2048601269609824256, 2048601269345583104, 2049629108253622282),
+(4000000000000000021, 4000000000000000011, 2049629108245233664),
+(4000000000000000022, 4000000000000000011, 2049629108253622282),
+(4000000000000000023, 4000000000000000011, 2049629108245233668),
+(4000000000000000024, 4000000000000000011, 2049629108245233672),
+(4000000000000000025, 4000000000000000012, 2049629108245233664),
+(4000000000000000026, 4000000000000000012, 2049629108253622282),
+(4000000000000000027, 4000000000000000013, 2049629108245233664),
+(4000000000000000028, 4000000000000000013, 2049629108253622282);
+
+insert into sys_role_data_scope (id, role_id, data_scope_id)
+values
+(4000000000000000031, 4000000000000000011, 2048601269869871104),
+(4000000000000000032, 4000000000000000012, 2048601269806956544),
+(4000000000000000033, 4000000000000000013, 2048601269869871105);
 
 insert into sys_user (id, uuid, username, nickname, password, salt, email, status, is_superuser, is_staff, is_multi_login, avatar, timezone, phone, join_time, last_login_time, last_password_changed_time, dept_id, created_time, updated_time)
 values
 (2048601269672738816, gen_random_uuid(), 'admin', '用户88888', '$2b$12$8y2eNucX19VjmZ3tYhBLcOsBwy9w1IjBQE4SSqwMDL5bGQVp2wqS.', decode('24326224313224387932654E7563583139566A6D5A33745968424C634F', 'hex'), 'admin@example.com', 1, true, true, true, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601264366944256, now(), null),
-(2049946297615646720, gen_random_uuid(), 'test', '用户66666', '$2b$12$BMiXsNQAgTx7aNc7kVgnwedXGyUxPEHRnJMFbiikbqHgVoT3y14Za', decode('24326224313224424D6958734E514167547837614E63376B56676E7765', 'hex'), 'test@example.com', 1, false, false, false, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601264366944256, now(), null);
+(2049946297615646720, gen_random_uuid(), 'test', '用户66666', '$2b$12$BMiXsNQAgTx7aNc7kVgnwedXGyUxPEHRnJMFbiikbqHgVoT3y14Za', decode('24326224313224424D6958734E514167547837614E63376B56676E7765', 'hex'), 'test@example.com', 1, false, false, false, null, 'Asia/Shanghai', null, now(), now(), now(), 2048601264366944256, now(), null),
+(4000000000000000041, gen_random_uuid(), 'zhangwei', '张伟', '$2b$12$Pnvhzs0e1pJ8qyvB9Kkv1em/IpT.46XKEfPqoIoLR2ly8RVCVEcLS', decode('506E76687A73306531704A3871797642394B6B763165', 'hex'), 'zhangwei@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000001, now(), null),
+(4000000000000000042, gen_random_uuid(), 'lina', '李娜', '$2b$12$7xeTTK8azV4xXUGpZY7kBef7pfDj6ilVE1Pkt6VReNH5xd8kCgVEi', decode('37786554544B38617A563478585547705A59376B4265', 'hex'), 'lina@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000004, now(), null),
+(4000000000000000043, gen_random_uuid(), 'wangfang', '王芳', '$2b$12$rCfJ7pCZp/CsGhfbBcU9YuXzfYb8xl8Xm7AqSG5u0fiyoetNGInQ.', decode('7243664A3770435A702F437347686662426355395975', 'hex'), 'wangfang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000006, now(), null),
+(4000000000000000044, gen_random_uuid(), 'liuyang', '刘洋', '$2b$12$z958muAw9wAclhvxw6tzROV8vIR2COsPdakXXv4d7QF7litw1Wdl6', decode('7A3935386D754177397741636C6876787736747A524F', 'hex'), 'liuyang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000002, now(), null),
+(4000000000000000045, gen_random_uuid(), 'chenjing', '陈静', '$2b$12$wqmNVS86davwAaQWMA/kL.P1nU4CV3HAeLcq0XdMBRSbsY5N/KIoa', decode('77716D4E5653383664617677416151574D412F6B4C2E', 'hex'), 'chenjing@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000003, now(), null),
+(4000000000000000046, gen_random_uuid(), 'zhaolei', '赵磊', '$2b$12$aQ0gVSkO.pJi7iWXvx1UBujb9vnumYbTjhmoYlPgau/eo.t9oD0Pi', decode('6151306756536B4F2E704A6937695758767831554275', 'hex'), 'zhaolei@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000005, now(), null),
+(4000000000000000047, gen_random_uuid(), 'sunqiang', '孙强', '$2b$12$T06KtP5UZLuKbgEccyCBa.9bW9nIysTPn0WyX5Bc/B3cxwLvxW62W', decode('5430364B745035555A4C754B6267456363794342612E', 'hex'), 'sunqiang@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 4000000000000000005, now(), null),
+(4000000000000000048, gen_random_uuid(), 'zhoumin', '周敏', '$2b$12$PUJ3wLeG0VSqQoKdvu/NKuYcnyF4AgfZDES2UoktE3uAdTeergGB.', decode('50554A33774C654730565371516F4B6476752F4E4B75', 'hex'), 'zhoumin@example.com', 1, false, true, false, null, 'Asia/Shanghai', null, now(), null, now(), 2048601264366944256, now(), null);
 
 insert into sys_user_role (id, user_id, role_id)
 values
 (2048601269739847680, 2048601269672738816, 2048601269345583104),
-(2049946493732913152, 2049946297615646720, 2048601269345583104);
+(2049946493732913152, 2049946297615646720, 2048601269345583104),
+(4000000000000000051, 4000000000000000041, 4000000000000000011),
+(4000000000000000052, 4000000000000000042, 2048601269345583104),
+(4000000000000000053, 4000000000000000043, 4000000000000000012),
+(4000000000000000054, 4000000000000000044, 2048601269345583104),
+(4000000000000000055, 4000000000000000045, 2048601269345583104),
+(4000000000000000056, 4000000000000000046, 4000000000000000011),
+(4000000000000000057, 4000000000000000047, 2048601269345583104),
+(4000000000000000058, 4000000000000000048, 4000000000000000013);
 
 insert into sys_data_scope (id, name, status, created_time, updated_time)
 values
@@ -92,8 +133,8 @@ values
 insert into sys_data_rule (id, name, model, "column", operator, expression, "value", created_time, updated_time)
 values
 (2048601269932785664, '部门 ID 等于当前用户部门', '__ALL__', '__dept_id__', 0, 0, '${dept_id}', now(), null),
-(2048601269999894528, '部门编码等于 TEST', 'Dept', 'code', 1, 0, 'TEST', now(), null),
-(2048601269999894529, '父部门 ID 等于测试部门 ID', 'Dept', 'parent_id', 0, 0, '2048601264366944256', now(), null),
+(2048601269999894528, '部门编码等于 HQ', 'Dept', 'code', 1, 0, 'HQ', now(), null),
+(2048601269999894529, '父部门 ID 等于总部部门 ID', 'Dept', 'parent_id', 0, 0, '2048601264366944256', now(), null),
 (2048601269999894530, '创建者等于当前用户', '__ALL__', '__created_by__', 0, 0, '${user_id}', now(), null),
 (2048601269999894531, '全模型部门 ID 等于当前用户部门', '__ALL__', '__dept_id__', 0, 0, '${dept_id}', now(), null),
 (2048601269999894533, '用户非超级管理员', 'User', 'is_superuser', 0, 1, '1', now(), null);


### PR DESCRIPTION
## 问题
公开演示用的组织架构种子数据（总部+5个子部门、STAFF/MANAGER/FINANCE_STAFF/VIEWER
四个角色、8 个演示账号）之前只加进了 `backend/sql/sqlserver/init_snowflake_test_data.sql`，
`mysql`/`postgresql` 两份种子文件原地还是最初 1 部门 + 1 角色 + 2 账号的最小集合，没有任何
机器校验会抓这个漂移——现成的两条守卫都只比对「种子里的密码 hash 在不在白名单」，不比对
「三份种子内容是否一致」。

生产（跑 postgresql）的公开演示上线之后组织架构就一直是这个最小种子，直到发现"看着不像回事"
才注意到。

## 改了什么
- `backend/sql/mysql/init_snowflake_test_data.sql`、
  `backend/sql/postgresql/init_snowflake_test_data.sql`：补齐到跟 `sqlserver` 同样的
  部门/角色/账号内容，ID 各方言各自一套（mysql 复用 sqlserver 现成的 ID，postgresql
  改名复用原有 ID + 新增部分另起区间）
- `apps/api/AGENTS.md`：记一条踩坑——三份种子文件靠人工同步，没有自动化比对

## 验证
- `sql_parser.py` 白名单校验三份文件都过
- `test_seeded_password_hashes_cover_every_seeded_account` / `test_init_handles_every_seeded_account` 两条绿
- 线上 postgresql 库的数据同步是另一件事，会在合并后单独手动执行（写production DB，走过一次人工确认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)