### PR TITLE
fix: 列表页能刷新了——搜索变成幂等重取、每页一个刷新按钮、重新加载不再是空操作

### DIFF
--- a/apps/web/e2e/tests/list-refresh.spec.ts
+++ b/apps/web/e2e/tests/list-refresh.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "../fixtures/base"
+
+/**
+ * 列表页的「取最新」三条路径（issue #36 的回归）。
+ *
+ * 🔴 这一组**只能靠数请求**来验：这三个动作在界面上都长得像「有反应」
+ * （URL 变了 / 按钮转了一下 / 页面重挂了），而它们曾经**一个请求都不发** ——
+ * 界面上和「刷新过了，数据恰好没变」完全无法区分。
+ */
+test.describe("列表页刷新", () => {
+  test("条件未变点搜索、点刷新、标签页重新加载，三者都必须真的重取", async ({
+    authedPage: page,
+  }) => {
+    const hits: string[] = []
+    page.on("request", (r) => {
+      const u = new URL(r.url())
+      if (u.pathname === "/api/v1/sys/users") hits.push(u.search)
+    })
+
+    await page.goto("/system/user")
+    await expect(page.getByTestId("user-table")).toBeVisible()
+    await expect.poll(() => hits.length).toBeGreaterThan(0)
+
+    // ① 条件一个字都没改，再点一次搜索 —— 用户的心智模型是「照这些条件再查一次」
+    const afterLoad = hits.length
+    await page.getByRole("button", { name: "搜索" }).click()
+    await expect.poll(() => hits.length, { timeout: 5000 }).toBeGreaterThan(afterLoad)
+
+    // ② 工具行的刷新按钮：只重取，筛选/分页都留着
+    const beforeRefresh = hits.length
+    const url = page.url()
+    await page.getByTestId("list-refresh").click()
+    await expect.poll(() => hits.length, { timeout: 5000 }).toBeGreaterThan(beforeRefresh)
+    expect(page.url()).toBe(url)
+
+    // ③ 标签条的「重新加载当前页」—— 曾经在 staleTime(30s) 内是空操作
+    const beforeReload = hits.length
+    await page.getByTestId("tab-reload").click()
+    await expect.poll(() => hits.length, { timeout: 5000 }).toBeGreaterThan(beforeReload)
+  })
+
+  test("刷新会清掉行选中：重取回来的行可能已经不在了", async ({ authedPage: page }) => {
+    await page.goto("/system/user")
+    const table = page.getByTestId("user-table")
+    await expect(table.locator('[data-slot="table-body"] [data-slot="table-row"]').first()).toBeVisible()
+
+    // 勾一行（超管那行不给选，见 enableRowSelection）——「已选 N 项」出现即算选上
+    await table.getByRole("checkbox").nth(1).click()
+    await expect(page.getByTestId("bulk-count")).toBeVisible()
+
+    // 🔴 刷新要把选中清掉：重取回来的行可能已经不在了，而选中态是按 id 存的 ——
+    // 留着它，接下来的批量删除会打到用户看不见的记录上
+    await page.getByTestId("list-refresh").click()
+    await expect(page.getByTestId("bulk-count")).toBeHidden()
+  })
+})

--- a/packages/platform/src/pages/AGENTS.md
+++ b/packages/platform/src/pages/AGENTS.md
@@ -26,7 +26,7 @@ pages/xxx/
 | 文件 | 提供 |
 |---|---|
 | `_shared/status.tsx` | `TONE_CLASS` 色板 · `StatusPill` · `StatusBadge`（正常/停用）· `STATUS_FILTER_ITEMS` / `STATUS_FORM_ITEMS` · `YesNoBadge` |
-| `_shared/filters.tsx` | `TextFilter`（回车/失焦才写 URL）· `SelectFilter` · `StatusFilter` · `ResetButton` · `BulkBar` |
+| `_shared/filters.tsx` | `TextFilter`（回车/失焦才写 URL）· `SelectFilter` · `StatusFilter` · `ResetButton` · `BulkBar` · `RefreshButton`（见下「刷新」一节） |
 | `_shared/select-column.tsx` | `buildSelectColumn(col, { canSelect })` —— 表格首列的复选框（含半选态） |
 | `_shared/log-features.ts` | 除用户页外共用的 `tableFeatures()` |
 | `_shared/use-tree-fold.ts` | 树形表格的展开/折叠：URL 只放粗粒度 `fold=all`，逐个节点的展开留组件 state |
@@ -123,6 +123,37 @@ const list = listState(listQuery)               // loading / busy / error / onRe
 |---|---|
 | 次要工具动作（导出 / 清空 / 列） | 图标 + tooltip |
 | 主动作（搜索 / 重置 / 筛选视图） | 带文字 |
+
+### 🔴 「刷新」有三种语义，列表页要暴露的是最轻的那个
+
+| 语义 | 怎么做 | 界面上是谁 |
+|---|---|---|
+| **重取**：只重新请求，筛选 / 分页 / 展开 / 滚动 / 草稿全留着 | `refetch()` / `invalidateQueries` | 工具行的 `RefreshButton`（`_shared/filters.tsx`），接 `listState().onRetry` |
+| **重挂**：组件卸载重建，页面内状态全丢 | tab `revision + 1` **且**让缓存失效 | 标签条 / 右键菜单 / 命令面板的「重新加载当前页」 |
+| **整页**：F5 | 浏览器 | —— |
+
+以前列表页**一个都没有**（只有 plugin 页自己写了一个、主从页左栏有、监控页有），
+想看最新数据只能去标签条上按那个更重的动作，而它在 30 秒内还是空操作。issue #36。
+
+三条实测出来的纪律：
+
+- 🔴 **「搜索」必须是幂等的「照这些条件再查一次」。** `useQuerySearch` 的 `submit`
+  只写 URL —— 条件一个字都没改时 URL 不变、queryKey 不变，全局
+  `staleTime: 30_000` 让 react-query 直接给缓存：**实测 0 次请求**，连 spinner 都不闪，
+  和「刷新过了、数据恰好没变」完全无法区分。所以每个用 `QueryBar` 的页面都要给
+  `useQuerySearch` 传 `refreshKey`（这一页列表 query 的 key 前缀，如 `userKeys.all`），
+  submit / reset 时会顺手把它失效掉
+- 🔴 **刷新要清掉行选中**：`listState(query, { onBeforeRefetch: () => setRowSelection({}) })`。
+  重取回来的行可能已经不在了（别人删了），而选中态是按 `getRowId` 存的一组 id ——
+  留着它，接下来的批量删除会打到**用户看不见的记录**上。这和「改筛选要清 rowSelection」
+  是同一个坑，只是触发方式从「换条件」变成了「点刷新」
+- ⚠️ **刷新按钮不要用 `disabled` 挡重复点击。** `buttonVariants` 带
+  `disabled:pointer-events-none`，一禁用 hover 就打不开 tooltip，而它是个纯图标按钮 ——
+  「进行中」这个状态就没有任何地方读得到了。转圈 + `aria-busy` 表达在途
+
+「最后更新 hh:mm:ss」这一条**还没做**（监控页的 `RefreshBar` 已经有这个口径，
+列表页照抄即可）。自动刷新也没做，也不打算全站开 —— 中后台大多是编辑场景，
+表格自己跳会打断操作；真要给日志/任务记录开，复用监控页「间隔进 URL、0 = 手动」那套。
 
 ### 🔴 时间字段一律过 `formatDateTime`，不许裸渲染
 

--- a/packages/platform/src/pages/_shared/filters.tsx
+++ b/packages/platform/src/pages/_shared/filters.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { IconFilter, IconSearch, IconTrash, IconX } from '@tabler/icons-react'
+import { IconFilter, IconRefresh, IconSearch, IconTrash, IconX } from '@tabler/icons-react'
 
 import { Button } from '@admin/ui/components/button'
 import {
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@admin/ui/components/dropdown-menu'
 import { cn } from '@admin/ui/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@admin/ui/components/tooltip'
 import { Combobox } from '@admin/ui/components/combobox'
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
@@ -286,6 +287,53 @@ export function StatusFilter({
       testId={testId}
       onChange={(v) => onChange(v === undefined ? undefined : Number(v))}
     />
+  )
+}
+
+/**
+ * 列表页的「刷新」——**只重取当前这一页数据**，筛选 / 分页 / 展开 / 滚动全保留。
+ *
+ * 🔴 和标签页右键菜单里的「重新加载」不是一件事：那个是卸载重挂（页面内状态全丢）。
+ * 界面上必须两个都有、且名字不同 —— 想看最新数据的人要的是这个，
+ * 而以前**列表页一个都没有**，只能去标签条上按那个更重的动作（issue #36）。
+ *
+ * ⚠️ 图标按钮，配 tooltip（`packages/ui/AGENTS.md` 那条纪律：
+ * 次要工具动作只留图标，但少了 tooltip 就没人知道它是干什么的）。
+ * **不要用 `disabled` 挡重复点击** —— `buttonVariants` 带
+ * `disabled:pointer-events-none`，一禁用 hover 就打不开 tooltip，
+ * 「进行中」这个状态就没有任何地方读得到了。转圈 + `aria-busy` 表达在途。
+ */
+export function RefreshButton({
+  onClick,
+  busy,
+  testId = 'list-refresh',
+}: {
+  onClick: () => void
+  /** 在途中 —— 图标转圈 */
+  busy?: boolean
+  testId?: string
+}) {
+  const { t } = useTranslation()
+  const trigger = (
+    <Button
+      variant="outline"
+      size="sm"
+      className="size-8 p-0"
+      aria-label={t('刷新')}
+      aria-busy={busy}
+      data-testid={testId}
+      onClick={onClick}
+    />
+  )
+  return (
+    <Tooltip>
+      {/* render 必须直接指向按钮 —— 套一层 display:contents 的包装元素会让气泡
+          飞到视口左上角（见 packages/ui/AGENTS.md） */}
+      <TooltipTrigger render={trigger}>
+        <IconRefresh className={cn('size-4', busy && 'animate-spin')} />
+      </TooltipTrigger>
+      <TooltipContent>{t('刷新')}</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/packages/platform/src/pages/_shared/list-query.ts
+++ b/packages/platform/src/pages/_shared/list-query.ts
@@ -32,7 +32,13 @@ export type ListStateProps = {
   busy: boolean
   /** 取数失败 —— 传给 `DataTable` / `MasterList` 渲染错误块，不是空态 */
   error: unknown
-  /** 错误块上的「重试」 */
+  /**
+   * 重新取一次。
+   *
+   * 两个调用方共用它：错误块上的「重试」，以及工具行的「刷新」按钮
+   * （`_shared/filters.tsx` 的 `RefreshButton`）—— 两者要做的事完全一样，
+   * 不该有两条路径。
+   */
   onRetry: () => void
 }
 
@@ -52,14 +58,27 @@ export function listState(
      * 照搬会让骨架屏一直转（字典页没选类型时踩过）。
      */
     enabled?: boolean
+    /**
+     * 重取之前先做一件事。**有行选中的页面必须传 `() => setRowSelection({})`**：
+     *
+     * 🔴 重取回来的行可能已经不在了（别人删了 / 状态改了），而选中态是按
+     * `getRowId` 存的一组 id —— 留着它，接下来的批量删除会打到**用户看不见的
+     * 记录**上，而界面上没有任何异常（同硬纪律「改筛选要清 rowSelection」那条，
+     * 只是触发方式从「换条件」变成了「点刷新」）。
+     */
+    onBeforeRefetch?: () => void
   }
 ): ListStateProps {
   const enabled = options?.enabled ?? true
   const loading = enabled && query.isPending
+  const before = options?.onBeforeRefetch
   return {
     loading,
     busy: query.isFetching && !loading && !query.isFetchingNextPage,
     error: query.error ?? undefined,
-    onRetry: () => void query.refetch(),
+    onRetry: () => {
+      before?.()
+      void query.refetch()
+    },
   }
 }

--- a/packages/platform/src/pages/_shared/use-query-search.ts
+++ b/packages/platform/src/pages/_shared/use-query-search.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 
 import {
   emptyQuery, fromUrlParams, nextId, toQueryParams, toUrlParams, urlParamKeys,
@@ -62,12 +63,29 @@ export function useQuerySearch<S extends QuerySearch>({
   onSearchChange,
   /** 写回 URL 时要保留的键（`hide`、`section` 这种和筛选无关的视图状态） */
   keep,
+  /**
+   * 这一页列表 query 的 key 前缀（如 `userKeys.all`）。
+   *
+   * 🔴 传了它，「搜索」才是**幂等**的：条件一个字都没改时再点一次，也会真的
+   * 重新取一次数据。不传的话点搜索**什么都不会发生** —— `submit` 只写 URL，
+   * 条件没变 → URL 不变 → queryKey 不变 → 全局 `staleTime: 30_000` 让
+   * react-query 直接给缓存，连 spinner 都不闪（实测 0 次请求，issue #36）。
+   *
+   * 用户点搜索的心智模型是「照这些条件再查一次」，不是「如果条件变了才查」。
+   *
+   * ⚠️ 为什么是 key 前缀而不是直接收一个 `refetch`：`refetch` 来自
+   * `useQuery`，而 `useQuery` 的入参又来自这个 hook 返回的 `params` ——
+   * 顺序上拿不到。key 工厂是模块级常量，没有这个问题。
+   */
+  refreshKey,
 }: {
   fields: readonly FilterField[]
   search: S
   onSearchChange?: (next: S) => void
   keep?: readonly (keyof S)[]
+  refreshKey?: readonly unknown[]
 }) {
+  const qc = useQueryClient()
   /**
    * URL 里那一份 = **已经生效的那一份**。
    *
@@ -119,8 +137,10 @@ export function useQuerySearch<S extends QuerySearch>({
       Object.assign(out, toUrlParams(next, fields))
       onSearchChange?.(out as S)
       setValue(next)
+      // 条件没变时 URL 不变、queryKey 不变，只能靠这一下把缓存作废（见 refreshKey 的注释）
+      if (refreshKey) void qc.invalidateQueries({ queryKey: refreshKey })
     },
-    [fields, keep, managed, onSearchChange, search]
+    [fields, keep, managed, onSearchChange, qc, refreshKey, search]
   )
 
   const reset = React.useCallback(() => write(emptyQuery(fields)), [write, fields])

--- a/packages/platform/src/pages/dept/index.tsx
+++ b/packages/platform/src/pages/dept/index.tsx
@@ -25,7 +25,7 @@ import { cn } from '@admin/ui/lib/utils'
 import { Can } from '../../auth/can'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
-import { ResetButton, StatusFilter, TextFilter } from '../_shared/filters'
+import { RefreshButton, ResetButton, StatusFilter, TextFilter } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { StatusBadge } from '../_shared/status'
 import { useTreeFold } from '../_shared/use-tree-fold'
@@ -123,6 +123,7 @@ export function DeptPage({
               {foldAll ? <IconChevronsDown className="size-4" /> : <IconChevronsUp className="size-4" />}
               {foldAll ? t('展开全部') : t('折叠全部')}
             </Button>
+            <RefreshButton busy={isFetching} onClick={list.onRetry} />
             <span className="ms-auto text-sm text-muted-foreground">{t('共 {{n}} 个部门', { n: total })}</span>
             <Can perm="sys:dept:add">
               <Button size="sm" data-testid="add-dept" onClick={() => openCreate(null)}>

--- a/packages/platform/src/pages/dict/index.tsx
+++ b/packages/platform/src/pages/dict/index.tsx
@@ -20,7 +20,7 @@ import { Can } from '../../auth/can'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
 import { MasterList, type MasterListItem } from '../_shared/master-list'
-import { BulkBar, ResetButton, TextFilter } from '../_shared/filters'
+import { BulkBar, RefreshButton, ResetButton, TextFilter } from '../_shared/filters'
 import { logFeatures as features } from '../_shared/log-features'
 import { buildSelectColumn } from '../_shared/select-column'
 import { StatusBadge } from '../_shared/status'
@@ -119,7 +119,10 @@ export function DictPage({
   const { data: datasPage, isFetching } = datasQuery
   // 没选类型时这个 query 是 disabled 的（状态一直停在 pending）——
   // `enabled` 一定要传，否则骨架屏会一直转
-  const dataList = listState(datasQuery, { enabled: Boolean(selectedId) })
+  const dataList = listState(datasQuery, {
+    enabled: Boolean(selectedId),
+    onBeforeRefetch: () => setRowSelection({}),
+  })
   const datas = datasPage?.items ?? []
 
   const [typeSheet, setTypeSheet] = React.useState(false)
@@ -328,6 +331,7 @@ export function DictPage({
                   {...dataList}
                   toolbar={
                     <>
+                      <RefreshButton busy={isFetching} onClick={dataList.onRetry} />
                       <TextFilter
                         value={search.q ?? ''}
                         placeholder={t("搜索字典项…")}

--- a/packages/platform/src/pages/file/index.tsx
+++ b/packages/platform/src/pages/file/index.tsx
@@ -15,7 +15,7 @@ import { Can } from '../../auth/can'
 import { fetchBytes } from '../../api-client/client'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
-import { ResetButton, TextFilter } from '../_shared/filters'
+import { RefreshButton, ResetButton, TextFilter } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import {
   filesQuery,
@@ -91,7 +91,8 @@ export function FilePage({
   }
   const listQuery = useQuery(filesQuery(params))
   const { data, isPending, isFetching } = listQuery
-  const list = listState(listQuery)
+  // 刷新/重试前清掉选中：重取回来可能已经少了几个文件（见 list-query.ts）
+  const list = listState(listQuery, { onBeforeRefetch: () => setSelected(new Set()) })
   const files = data?.items ?? []
   const total = data?.total ?? 0
   const totalPages = data?.total_pages ?? 1
@@ -202,6 +203,7 @@ export function FilePage({
           <div className="flex min-w-0 flex-1 flex-col gap-3 content-scroll:min-h-0">
             {/* 工具栏 */}
             <div className="flex flex-wrap items-center gap-2">
+              <RefreshButton busy={isFetching && !isPending} onClick={list.onRetry} />
               <TextFilter
                 value={search.name ?? ''}
                 placeholder={t('搜索文件名…')}

--- a/packages/platform/src/pages/log-login/index.tsx
+++ b/packages/platform/src/pages/log-login/index.tsx
@@ -16,7 +16,7 @@ import { api, type PageData } from '../../api-client/client'
 import { Can } from '../../auth/can'
 import { PageHeader } from '../../shell/page-header'
 import { ClearLogsButton } from '../_shared/clear-logs'
-import { ResetButton } from '../_shared/filters'
+import { RefreshButton, ResetButton } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { useQuerySearch } from '../_shared/use-query-search'
 import { useUrlColumnVisibility } from '../_shared/use-column-visibility'
@@ -25,6 +25,10 @@ import { StatusPill } from '../_shared/status'
 import { LoginLogDetailSheet, formatLocation } from './detail-sheet'
 import type { LoginLog } from '../_shared/login-log'
 import { DEFAULT_PAGE_SIZE } from '../_shared/pagination'
+
+/** 这一页列表 query 的 key 前缀。`useQuerySearch` 的 `refreshKey` 也用它 ——
+ *  「点搜索必须真的重取」靠让这个前缀失效实现（见 use-query-search.ts） */
+const LOG_KEY = ['logs', 'login'] as const
 
 export type { LoginLog }
 
@@ -148,12 +152,13 @@ export function LogLoginPage({
     fields: FIELDS,
     search,
     onSearchChange,
+    refreshKey: LOG_KEY,
     keep: ['hide'],
   })
 
   const qs = buildQuery(q.params, search.page, search.size)
   const listQuery = useQuery({
-    queryKey: ['logs', 'login', qs],
+    queryKey: [...LOG_KEY, qs],
     queryFn: () => api.GET<PageData<LoginLog>>(`/api/v1/logs/login?${qs}`),
     placeholderData: (prev) => prev,
   })
@@ -369,6 +374,7 @@ export function LogLoginPage({
               loading={isFetching}
               actions={
                 <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/*
                   这三个是**次要的工具动作**，只留图标：这一行已经有六个控件，
                   留着文字会把主动作（搜索）挤到边上。图标按钮一律配

--- a/packages/platform/src/pages/log-opera/index.tsx
+++ b/packages/platform/src/pages/log-opera/index.tsx
@@ -16,7 +16,7 @@ import { api, type PageData } from '../../api-client/client'
 import { Can } from '../../auth/can'
 import { PageHeader } from '../../shell/page-header'
 import { ClearLogsButton } from '../_shared/clear-logs'
-import { ResetButton } from '../_shared/filters'
+import { RefreshButton, ResetButton } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { useQuerySearch } from '../_shared/use-query-search'
 import { useUrlColumnVisibility } from '../_shared/use-column-visibility'
@@ -24,6 +24,10 @@ import { logFeatures as features } from '../_shared/log-features'
 import { StatusPill } from '../_shared/status'
 import { OperaLogDetailSheet, formatLocation } from './detail-sheet'
 import { DEFAULT_PAGE_SIZE } from '../_shared/pagination'
+
+/** 这一页列表 query 的 key 前缀。`useQuerySearch` 的 `refreshKey` 也用它 ——
+ *  「点搜索必须真的重取」靠让这个前缀失效实现（见 use-query-search.ts） */
+const LOG_KEY = ['logs', 'opera'] as const
 
 export type OperaLog = {
   id: string
@@ -165,12 +169,13 @@ export function LogOperaPage({
     fields: FIELDS,
     search,
     onSearchChange,
+    refreshKey: LOG_KEY,
     keep: ['hide'],
   })
 
   const qs = buildQuery(q.params, search.page, search.size)
   const listQuery = useQuery({
-    queryKey: ['logs', 'opera', qs],
+    queryKey: [...LOG_KEY, qs],
     queryFn: () => api.GET<PageData<OperaLog>>(`/api/v1/logs/opera?${qs}`),
     placeholderData: (prev) => prev,
   })
@@ -429,6 +434,7 @@ export function LogOperaPage({
               loading={isFetching}
               actions={
                 <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/*
                   这三个是**次要的工具动作**，只留图标：这一行已经有六个控件，
                   留着文字会把主动作（搜索）挤到边上。图标按钮一律配

--- a/packages/platform/src/pages/menu/index.tsx
+++ b/packages/platform/src/pages/menu/index.tsx
@@ -25,7 +25,7 @@ import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { MenuIcon } from '../../shell/icon-registry'
 import { PageHeader } from '../../shell/page-header'
 import { usePlatform } from '../../shell/platform-context'
-import { ResetButton, SelectFilter, StatusFilter, TextFilter } from '../_shared/filters'
+import { RefreshButton, ResetButton, SelectFilter, StatusFilter, TextFilter } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { StatusBadge, TONE_CLASS } from '../_shared/status'
 import { useTreeFold } from '../_shared/use-tree-fold'
@@ -181,6 +181,7 @@ export function MenuPage({
                 </Tooltip>
               )}
             </span>
+            <RefreshButton busy={isFetching} onClick={list.onRetry} />
             <Can perm="sys:menu:add">
               <Button size="sm" data-testid="add-menu"
                       onClick={() => { setEditing(null); setPresetParent(null); setSheet(true) }}>

--- a/packages/platform/src/pages/notice/index.tsx
+++ b/packages/platform/src/pages/notice/index.tsx
@@ -11,10 +11,10 @@ import { QueryBar, countActive, type FilterField } from '@admin/ui/components/qu
 import { Can } from '../../auth/can'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
-import { BulkBar, ResetButton } from '../_shared/filters'
+import { BulkBar, RefreshButton, ResetButton } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { useQuerySearch } from '../_shared/use-query-search'
-import { noticesQuery, useDeleteNotices, type Notice, type NoticeListParams } from './api'
+import { noticeKeys, noticesQuery, useDeleteNotices, type Notice, type NoticeListParams } from './api'
 import { COLUMN_LABELS, buildColumns } from './columns'
 import { NoticeDetailSheet } from './detail-sheet'
 import { features } from './table-features'
@@ -109,7 +109,7 @@ export function NoticePage({
    * 可见行里，批量删除会打到看不见的记录上（原来 `patch` 顺手做的那件事）。
    */
   // 这一页的列显隐是组件内 state（没进 URL），所以 keep 里没有 'hide'
-  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange })
+  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange, refreshKey: noticeKeys.all })
   const submitQuery = React.useCallback(
     (v: Parameters<typeof q.submit>[0]) => {
       setRowSelection({})
@@ -121,7 +121,7 @@ export function NoticePage({
   const params = { page, size, ...q.params } as NoticeListParams
   const listQuery = useQuery(noticesQuery(params))
   const { data, isFetching } = listQuery
-  const list = listState(listQuery)
+  const list = listState(listQuery, { onBeforeRefetch: () => setRowSelection({}) })
   const rows = data?.items ?? []
   const total = data?.total ?? 0
   const totalPages = data?.total_pages ?? 1
@@ -187,6 +187,7 @@ export function NoticePage({
               viewsStorageKey="qb:notice"
               actions={
                 <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <Can perm="sys:notice:add">
                     <Button
                       size="sm"

--- a/packages/platform/src/pages/scheduler-manage/index.tsx
+++ b/packages/platform/src/pages/scheduler-manage/index.tsx
@@ -15,7 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@admin/ui/components/to
 import { Can } from '../../auth/can'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
-import { ResetButton } from '../_shared/filters'
+import { RefreshButton, ResetButton } from '../_shared/filters'
 import { logFeatures as features } from '../_shared/log-features'
 import { DEFAULT_PAGE_SIZE } from '../_shared/pagination'
 import { StatusPill } from '../_shared/status'
@@ -24,7 +24,7 @@ import { useQuerySearch } from '../_shared/use-query-search'
 import { useUrlColumnVisibility } from '../_shared/use-column-visibility'
 import {
   SCHEDULER_TYPE_LABEL,
-  describeSchedule, schedulerMetaQuery, schedulersQuery,
+  describeSchedule, schedulerKeys, schedulerMetaQuery, schedulersQuery,
   useDeleteSchedulers, useRunScheduler, useToggleScheduler,
   type TaskScheduler,
 } from './api'
@@ -82,7 +82,7 @@ export function SchedulerManagePage({
     [onSearchChange, search]
   )
 
-  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange, keep: ['hide'] })
+  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange, keep: ['hide'], refreshKey: schedulerKeys.all })
   const listQuery = useQuery(
     schedulersQuery({ page, size, ...(q.params as Record<string, string>) })
   )
@@ -289,6 +289,7 @@ export function SchedulerManagePage({
               loading={isFetching}
               actions={
                 <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <Can perm="task:scheduler:add">
                     <Button
                       size="sm"

--- a/packages/platform/src/pages/scheduler-record/index.tsx
+++ b/packages/platform/src/pages/scheduler-record/index.tsx
@@ -8,7 +8,7 @@ import { DataTable, DataTableColumnVisibility } from '@admin/ui/components/data-
 import { QueryBar, countActive, type FilterField } from '@admin/ui/components/query-bar'
 
 import { PageHeader } from '../../shell/page-header'
-import { ResetButton } from '../_shared/filters'
+import { RefreshButton, ResetButton } from '../_shared/filters'
 import { logFeatures as features } from '../_shared/log-features'
 import { DEFAULT_PAGE_SIZE } from '../_shared/pagination'
 import { StatusPill } from '../_shared/status'
@@ -19,6 +19,7 @@ import {
   RESULT_STATUS_FILTER_ITEMS,
   RESULT_STATUS_LABEL,
   RESULT_STATUS_TONE,
+  resultKeys,
   resultsQuery,
   type TaskResult,
 } from './api'
@@ -95,7 +96,7 @@ export function SchedulerRecordPage({
     [onSearchChange, search]
   )
 
-  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange, keep: ['hide'] })
+  const q = useQuerySearch({ fields: FIELDS, search, onSearchChange, keep: ['hide'], refreshKey: resultKeys.all })
 
   const listQuery = useQuery(
     resultsQuery({ page, size, ...(q.params as Record<string, string>) })
@@ -229,7 +230,12 @@ export function SchedulerRecordPage({
               onReset={q.reset}
               applied={q.applied}
               loading={isFetching}
-              actions={<DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />}
+              actions={
+                <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
+                  <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
+                </>
+              }
             />
 
             <div

--- a/packages/platform/src/pages/user/index.tsx
+++ b/packages/platform/src/pages/user/index.tsx
@@ -11,7 +11,7 @@ import { QueryBar, countActive, type FilterField } from '@admin/ui/components/qu
 import { Can, SuperOnly } from '../../auth/can'
 import { ConfirmDialog } from '../../shell/confirm-dialog'
 import { PageHeader } from '../../shell/page-header'
-import { BulkBar, ResetButton } from '../_shared/filters'
+import { BulkBar, RefreshButton, ResetButton } from '../_shared/filters'
 import { listState } from '../_shared/list-query'
 import { useQuerySearch } from '../_shared/use-query-search'
 import { useUrlColumnVisibility } from '../_shared/use-column-visibility'
@@ -19,6 +19,7 @@ import {
   allRolesQuery,
   deptTreeQuery,
   flattenDepts,
+  userKeys,
   usersQuery,
   useDeleteUser,
   useDeleteUsers,
@@ -159,7 +160,7 @@ export function UserPage({
    * ⚠️ 搜索/重置时要**清掉选中行**：分页在服务端，换了筛选条件之后留着的选中项
    * 已经不在可见行里了，批量删除会打到用户看不见的记录上（原来 `patch` 里做的那件事）。
    */
-  const q = useQuerySearch({ fields, search, onSearchChange, keep: ['hide'] })
+  const q = useQuerySearch({ fields, search, onSearchChange, keep: ['hide'], refreshKey: userKeys.all })
   const submitQuery = React.useCallback(
     (v: Parameters<typeof q.submit>[0]) => {
       setRowSelection({})
@@ -172,7 +173,8 @@ export function UserPage({
   const params = { page, size, ...q.params } as UserListParams
   const listQuery = useQuery(usersQuery(params))
   const { data, isFetching } = listQuery
-  const list = listState(listQuery)
+  // 刷新/重试前清掉选中：重取回来的行可能已经不在了（见 list-query.ts 的注释）
+  const list = listState(listQuery, { onBeforeRefetch: () => setRowSelection({}) })
   const rows = data?.items ?? []
   const total = data?.total ?? 0
   const totalPages = data?.total_pages ?? 1
@@ -244,6 +246,7 @@ export function UserPage({
               viewsStorageKey="qb:user"
               actions={
                 <>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/* 新增用户后端是 DependsSuperUser（user.py:71），不是权限码校验，
                       按 isSuperuser 直判，别用 <Can perm="..."> 编一个假权限码 */}
                   <SuperOnly>

--- a/packages/platform/src/shell/AGENTS.md
+++ b/packages/platform/src/shell/AGENTS.md
@@ -120,6 +120,13 @@ inset（SidebarInset）       content-scroll:min-h-0
   透传到 `Popup` 是无效的（`ui/dropdown-menu.tsx` 已补透传）。锚到鼠标坐标用零尺寸虚拟矩形
 - **「重新加载」= `revision + 1`**，`TabOutlet` 把它拼进页面组件的 key → 卸载重挂。
   `<Activity>` 保活的页面不换 key 是刷不掉的（state 和已取数据都会留着）
+- 🔴 **但光重挂不够，必须同时 `invalidateQueries`。** 全局 `staleTime: 30_000` 让
+  react-query 认为数据还新鲜，`refetchOnMount` 于是不发请求 —— 实测「重新加载当前页」
+  在 30 秒内是**空操作**（0 次请求），30 秒后才真的重取。一个动作的行为取决于
+  「你上次看它是几秒前」，是最反直觉的那种坏（issue #36）。
+  用 `refetchType: 'active'`：只有当前可见页面立刻重取，隐藏 tab 的 query 没有观察者
+  （`<Activity>` 销毁了 effects），只标记过期、等切回来再取。
+  **刻意不改全局 `staleTime`** —— 30 秒是为了「多页签切来切去不打后端」，那条理由仍然成立
 - 活动 tab 自动滚入视区时，`querySelector` **必须从标签条自己的 ref 往下找** ——
   隐藏 tab 的页面 DOM 还在文档树里（见硬纪律 5）
 - 滚轮横滚要**手动注册非 passive 监听**：React 的 `onWheel` 是 passive 的，

--- a/packages/platform/src/shell/use-tab-actions.ts
+++ b/packages/platform/src/shell/use-tab-actions.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 
 import { isRemovable, useTabStore, type Tab } from './tab-store'
@@ -12,6 +13,7 @@ import { isRemovable, useTabStore, type Tab } from './tab-store'
  */
 export function useTabActions() {
   const navigate = useNavigate()
+  const qc = useQueryClient()
 
   const go = React.useCallback((href: string) => void navigate({ to: href }), [navigate])
 
@@ -44,8 +46,24 @@ export function useTabActions() {
       },
       closeAll: () => goKey(s().closeAll()),
       togglePin: (key: string) => s().togglePin(key),
-      /** 重新加载：revision +1，TabOutlet 靠它换 key 重挂页面 */
-      reload: (key: string) => s().reload(key),
+      /**
+       * 重新加载：revision +1，TabOutlet 靠它换 key 重挂页面。
+       *
+       * 🔴 **必须同时把缓存作废**，光重挂是不够的：全局 `staleTime: 30_000`
+       * 让 react-query 认为数据还新鲜，`refetchOnMount` 于是不发请求 ——
+       * 实测「重新加载当前页」在 30 秒内是**空操作**（0 次请求），30 秒后才
+       * 真的重取。一个动作的行为取决于「你上次看它是几秒前」，是最反直觉的
+       * 那种坏（issue #36）。
+       *
+       * `refetchType: 'active'` —— 只有当前可见页面的 query 立刻重取；隐藏 tab
+       * 的 query 没有观察者（`<Activity>` 销毁了 effects），只标记为过期，
+       * 等它被切回来时再取。刻意不改全局 `staleTime`：30 秒是为了「多页签切来
+       * 切去不打后端」，那个理由仍然成立。
+       */
+      reload: (key: string) => {
+        void qc.invalidateQueries({ refetchType: 'active' })
+        s().reload(key)
+      },
       openInNewWindow: (tab: Tab) => window.open(tab.href, '_blank', 'noopener,noreferrer'),
     }
   }, [go, goKey])


### PR DESCRIPTION
closes #36

## 改之前的三个空操作（实测数请求）

| 动作 | `GET /sys/users` 请求数 |
|---|---|
| 条件没变，点「搜索」 | **0** |
| 标签条「重新加载当前页」（30 秒内） | **0** |
| 列表页的「刷新」 | —— 8 个主力列表页压根没有这个按钮 |

叠起来的结果：想看最新数据只能 F5，而它把多页签、展开状态、滚动位置、没提交的草稿全重置。

## 三处根因

1. `useQuerySearch.submit` **只写 URL**。条件没变 → URL 不变 → queryKey 不变 → 全局 `staleTime: 30_000` 直接给缓存，连 spinner 都不闪
2. 同一个 `staleTime` 让**重挂也不发请求**（`refetchOnMount` 只在 stale 时取），于是「重新加载当前页」的行为取决于「你上次看它是几秒前」
3. 列表页没有「只重取」这个入口（只有 plugin 页自己写了一个、主从页左栏有、监控页有）

## 改法

| 改哪 | 做什么 |
|---|---|
| `useQuerySearch` | 新增 `refreshKey`（列表 query 的 key 前缀），submit / reset 时无条件 `invalidateQueries` |
| `_shared/filters.tsx` | 新增 `RefreshButton`（图标 + tooltip + 转圈），接 `listState().onRetry` —— 和错误块「重试」共用同一条路径 |
| `listState` | 新增 `onBeforeRefetch`，有行选中的页面传 `() => setRowSelection({})` |
| `use-tab-actions.reload()` | `revision + 1` 之外，同时 `invalidateQueries({ refetchType: 'active' })` |

两个设计取舍值得说：

- **`refreshKey` 为什么是 key 前缀而不是收一个 `refetch`**：`refetch` 来自 `useQuery`，而 `useQuery` 的入参又来自这个 hook 返回的 `params` —— 顺序上拿不到。key 工厂是模块级常量，没这个问题
- 🔴 **刷新要清行选中**：重取回来的行可能已经不在了（别人删了），而选中态是按 `getRowId` 存的一组 id —— 留着它，接下来的批量删除会打到**用户看不见的记录**上。和「改筛选要清 `rowSelection`」是同一个坑，只是触发方式换成了点刷新
- **刻意不动全局 `staleTime`**：30 秒是为了「多页签切来切去不打后端」，那条理由仍然成立。`refetchType: 'active'` 让隐藏 tab 的 query 只标记过期、切回来再取

接上了 10 个页面：`user` · `notice` · `scheduler-manage` · `scheduler-record` · `log-login` · `log-opera`（这 6 个走 QueryBar 的同时接了 `refreshKey`）+ `file` · `dict` 右栏 · `dept` · `menu`。

## 没做的两步（#36 的第 3、5 步）

- **「最后更新 hh:mm:ss」**：监控页的 `RefreshBar` 已经有这个口径，列表页照抄即可，但那是 10 个页面 × 一次摆放决定，单独做更清楚
- **自动刷新**：不打算全站开 —— 中后台大多是编辑场景，表格自己跳会打断操作。真要给日志/任务记录开，复用监控页「间隔进 URL、0 = 手动」那套

## 验证

新增 `apps/web/e2e/tests/list-refresh.spec.ts`：

- 上面那张表逐格数请求 —— 条件未变点搜索 / 点刷新 / 标签页重新加载，三者都必须 > 0；刷新后 URL 不变（筛选、分页都还在）
- 刷新会清掉行选中（勾一行 → 刷新 → 「已选 N 项」消失）

🔴 这一组**只能靠数请求验**：三个动作在界面上都长得像「有反应」（URL 变了 / 按钮转了一下 / 页面重挂了），而它们曾经一个请求都不发 —— 和「刷新过了、数据恰好没变」完全无法区分。

全套 e2e **53 passed / 1 skipped**；`typecheck --force` · `i18n:check` · `ctx:check` · `pnpm --filter web lint` 全绿。结论写进 pages 分册（「刷新」的三种语义 + 三条纪律）与 shell 分册（reload 那条）。

> ⚠️ `ctx:check` 有一条既存警告：`apps/api/AGENTS.md` 582 行超预算（不是这个 PR 造成的，那份文件在别的 PR 里长起来的），该拆了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)