### PR TITLE
fix(ui): 刷新按钮挪到「列」前面，主动作保持在最前

### DIFF
--- a/apps/web/e2e/tests/list-refresh.spec.ts
+++ b/apps/web/e2e/tests/list-refresh.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "../fixtures/base"
 
 /**
+ * ⚠️ 定位一律按 **routeId** 收窄（`[data-tab="/_auth/system/user"]`）：
+ * 隐藏 tab 的 DOM 也在文档树里，多开一个列表页就有第二个
+ * `data-testid="list-refresh"`，strict mode 会当场撞两个（见根 CLAUDE.md 硬纪律 5）。
+ */
+const PAGE = '[data-tab="/_auth/system/user"]'
+
+/**
  * 列表页的「取最新」三条路径（issue #36 的回归）。
  *
  * 🔴 这一组**只能靠数请求**来验：这三个动作在界面上都长得像「有反应」
@@ -23,13 +30,13 @@ test.describe("列表页刷新", () => {
 
     // ① 条件一个字都没改，再点一次搜索 —— 用户的心智模型是「照这些条件再查一次」
     const afterLoad = hits.length
-    await page.getByRole("button", { name: "搜索" }).click()
+    await page.locator(`${PAGE} button`).filter({ hasText: "搜索" }).first().click()
     await expect.poll(() => hits.length, { timeout: 5000 }).toBeGreaterThan(afterLoad)
 
     // ② 工具行的刷新按钮：只重取，筛选/分页都留着
     const beforeRefresh = hits.length
     const url = page.url()
-    await page.getByTestId("list-refresh").click()
+    await page.locator(`${PAGE} [data-testid="list-refresh"]`).click()
     await expect.poll(() => hits.length, { timeout: 5000 }).toBeGreaterThan(beforeRefresh)
     expect(page.url()).toBe(url)
 
@@ -50,7 +57,7 @@ test.describe("列表页刷新", () => {
 
     // 🔴 刷新要把选中清掉：重取回来的行可能已经不在了，而选中态是按 id 存的 ——
     // 留着它，接下来的批量删除会打到用户看不见的记录上
-    await page.getByTestId("list-refresh").click()
+    await page.locator(`${PAGE} [data-testid="list-refresh"]`).click()
     await expect(page.getByTestId("bulk-count")).toBeHidden()
   })
 })

--- a/packages/platform/src/pages/AGENTS.md
+++ b/packages/platform/src/pages/AGENTS.md
@@ -135,7 +135,12 @@ const list = listState(listQuery)               // loading / busy / error / onRe
 以前列表页**一个都没有**（只有 plugin 页自己写了一个、主从页左栏有、监控页有），
 想看最新数据只能去标签条上按那个更重的动作，而它在 30 秒内还是空操作。issue #36。
 
-三条实测出来的纪律：
+**摆放位置固定**：主动作（新增 / 导出，带文字的）在前，次要图标工具聚在最右 ——
+`… [新增] [刷新] [列]`。刷新**贴着「列」**，两个都是纯图标的一天点不了一次的工具，
+分开摆会让人以为它们是两类东西。没有「列」的页面（树形页 / 文件页）就放在那一行最右端
+（文件页贴着视图切换那组图标）。
+
+四条实测出来的纪律：
 
 - 🔴 **「搜索」必须是幂等的「照这些条件再查一次」。** `useQuerySearch` 的 `submit`
   只写 URL —— 条件一个字都没改时 URL 不变、queryKey 不变，全局
@@ -147,6 +152,9 @@ const list = listState(listQuery)               // loading / busy / error / onRe
   重取回来的行可能已经不在了（别人删了），而选中态是按 `getRowId` 存的一组 id ——
   留着它，接下来的批量删除会打到**用户看不见的记录**上。这和「改筛选要清 rowSelection」
   是同一个坑，只是触发方式从「换条件」变成了「点刷新」
+- ⚠️ **E2E 定位刷新按钮要按 routeId 收窄**（`[data-tab="/_auth/system/user"] [data-testid="list-refresh"]`）：
+  隐藏 tab 的 DOM 也在文档树里，多开一个列表页就有第二个同名 testid，
+  strict mode 当场撞两个（硬纪律 5）
 - ⚠️ **刷新按钮不要用 `disabled` 挡重复点击。** `buttonVariants` 带
   `disabled:pointer-events-none`，一禁用 hover 就打不开 tooltip，而它是个纯图标按钮 ——
   「进行中」这个状态就没有任何地方读得到了。转圈 + `aria-busy` 表达在途

--- a/packages/platform/src/pages/dept/index.tsx
+++ b/packages/platform/src/pages/dept/index.tsx
@@ -123,7 +123,6 @@ export function DeptPage({
               {foldAll ? <IconChevronsDown className="size-4" /> : <IconChevronsUp className="size-4" />}
               {foldAll ? t('展开全部') : t('折叠全部')}
             </Button>
-            <RefreshButton busy={isFetching} onClick={list.onRetry} />
             <span className="ms-auto text-sm text-muted-foreground">{t('共 {{n}} 个部门', { n: total })}</span>
             <Can perm="sys:dept:add">
               <Button size="sm" data-testid="add-dept" onClick={() => openCreate(null)}>
@@ -131,6 +130,7 @@ export function DeptPage({
                 {t('新增部门')}
               </Button>
             </Can>
+            <RefreshButton busy={isFetching} onClick={list.onRetry} />
           </div>
 
           {/* 有旧数据可看时（重取失败那种）不抽走表格，错误挂成横幅 */}

--- a/packages/platform/src/pages/dict/index.tsx
+++ b/packages/platform/src/pages/dict/index.tsx
@@ -329,9 +329,11 @@ export function DictPage({
                     ) : undefined
                   }
                   {...dataList}
+                  // 「刷新」和「列」是一组次要图标工具，聚在右端；
+                  // 左边的 toolbar 留给筛选与批量条
+                  actions={<RefreshButton busy={isFetching} onClick={dataList.onRetry} />}
                   toolbar={
                     <>
-                      <RefreshButton busy={isFetching} onClick={dataList.onRetry} />
                       <TextFilter
                         value={search.q ?? ''}
                         placeholder={t("搜索字典项…")}

--- a/packages/platform/src/pages/file/index.tsx
+++ b/packages/platform/src/pages/file/index.tsx
@@ -203,7 +203,6 @@ export function FilePage({
           <div className="flex min-w-0 flex-1 flex-col gap-3 content-scroll:min-h-0">
             {/* 工具栏 */}
             <div className="flex flex-wrap items-center gap-2">
-              <RefreshButton busy={isFetching && !isPending} onClick={list.onRetry} />
               <TextFilter
                 value={search.name ?? ''}
                 placeholder={t('搜索文件名…')}
@@ -247,6 +246,7 @@ export function FilePage({
                   </>
                 )}
 
+                <RefreshButton busy={isFetching && !isPending} onClick={list.onRetry} />
                 <ToggleGroup
                   value={[view]}
                   onValueChange={(v) => {

--- a/packages/platform/src/pages/log-login/index.tsx
+++ b/packages/platform/src/pages/log-login/index.tsx
@@ -374,7 +374,6 @@ export function LogLoginPage({
               loading={isFetching}
               actions={
                 <>
-                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/*
                   这三个是**次要的工具动作**，只留图标：这一行已经有六个控件，
                   留着文字会把主动作（搜索）挤到边上。图标按钮一律配
@@ -416,6 +415,7 @@ export function LogLoginPage({
                   {/* 日志只增不减，之前界面上没有任何清理入口 —— 权限码 log:login:clear 一直闲置 */}
                   <ClearLogsButton kind="login" filtered={hasFilter} total={data?.total ?? 0} iconOnly />
                   {/* 「列」下拉从 DataTable 搬过来 —— 它自己那一行就整行消失了 */}
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
                 </>
               }

--- a/packages/platform/src/pages/log-opera/index.tsx
+++ b/packages/platform/src/pages/log-opera/index.tsx
@@ -434,7 +434,6 @@ export function LogOperaPage({
               loading={isFetching}
               actions={
                 <>
-                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/*
                   这三个是**次要的工具动作**，只留图标：这一行已经有六个控件，
                   留着文字会把主动作（搜索）挤到边上。图标按钮一律配
@@ -476,6 +475,7 @@ export function LogOperaPage({
                   {/* 日志只增不减，之前界面上没有任何清理入口 —— 权限码 log:opera:clear 一直闲置 */}
                   <ClearLogsButton kind="opera" filtered={hasFilter} total={data?.total ?? 0} iconOnly />
                   {/* 「列」下拉从 DataTable 搬过来 —— 它自己那一行就整行消失了 */}
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
                 </>
               }

--- a/packages/platform/src/pages/menu/index.tsx
+++ b/packages/platform/src/pages/menu/index.tsx
@@ -181,13 +181,13 @@ export function MenuPage({
                 </Tooltip>
               )}
             </span>
-            <RefreshButton busy={isFetching} onClick={list.onRetry} />
             <Can perm="sys:menu:add">
               <Button size="sm" data-testid="add-menu"
                       onClick={() => { setEditing(null); setPresetParent(null); setSheet(true) }}>
                 <IconPlus className="size-4" />{t('新增菜单')}
               </Button>
             </Can>
+            <RefreshButton busy={isFetching} onClick={list.onRetry} />
           </div>
 
           {/* 有旧数据可看时（重取失败那种）不抽走表格，错误挂成横幅 */}

--- a/packages/platform/src/pages/notice/index.tsx
+++ b/packages/platform/src/pages/notice/index.tsx
@@ -187,7 +187,6 @@ export function NoticePage({
               viewsStorageKey="qb:notice"
               actions={
                 <>
-                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <Can perm="sys:notice:add">
                     <Button
                       size="sm"
@@ -201,6 +200,7 @@ export function NoticePage({
                       {t('新增公告')}
                     </Button>
                   </Can>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
                   {/* 批量条放左组末尾：它随选中行出现/消失，放右组会让「搜索/重置」横向位移 */}
                   <Can perm="sys:notice:del">

--- a/packages/platform/src/pages/scheduler-manage/index.tsx
+++ b/packages/platform/src/pages/scheduler-manage/index.tsx
@@ -289,7 +289,6 @@ export function SchedulerManagePage({
               loading={isFetching}
               actions={
                 <>
-                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <Can perm="task:scheduler:add">
                     <Button
                       size="sm"
@@ -300,6 +299,7 @@ export function SchedulerManagePage({
                       {t('新增')}
                     </Button>
                   </Can>
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
                 </>
               }

--- a/packages/platform/src/pages/user/index.tsx
+++ b/packages/platform/src/pages/user/index.tsx
@@ -246,7 +246,6 @@ export function UserPage({
               viewsStorageKey="qb:user"
               actions={
                 <>
-                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   {/* 新增用户后端是 DependsSuperUser（user.py:71），不是权限码校验，
                       按 isSuperuser 直判，别用 <Can perm="..."> 编一个假权限码 */}
                   <SuperOnly>
@@ -263,6 +262,7 @@ export function UserPage({
                     </Button>
                   </SuperOnly>
                   {/* 「列」下拉从 DataTable 搬过来 —— 它自己那一行就整行消失了 */}
+                  <RefreshButton busy={isFetching} onClick={list.onRetry} />
                   <DataTableColumnVisibility table={table} columnLabels={COLUMN_LABELS} />
                   {/*
                   批量条放**左组末尾**：选中行时它才出现，左组往右长进空白里，


### PR DESCRIPTION
#37 把刷新按钮插在了 `actions` 槽的**最前面**，于是任务管理那一行是 `[刷新][+ 新增][列]` —— 主动作被一个一天点不了一次的图标工具挤到第二位，而两个纯图标工具（刷新 / 列）反被拆到一行的两端。

现在固定成 **`… [新增] [刷新] [列]`**：主动作（新增 / 导出，带文字的）在前，次要图标工具聚在最右，刷新贴着「列」。

| 页面 | 结果 |
|---|---|
| `user` · `notice` · `scheduler-manage` | `[新增…] [刷新] [列]` |
| `log-login` · `log-opera` | `[导出] [清空] [刷新] [列]` |
| `dict` | 从左边的 `toolbar` 搬进 `actions`，于是渲染在 `DataTable` 自带的「列」左边 |
| `file` | 没有「列」，贴着视图切换那组图标（宫格 / 列表） |
| `dept` · `menu` | 树形页没有「列」，放那一行最右端（`[新增部门] [刷新]`） |

## 顺带修一个 E2E 的坑

`getByTestId('list-refresh')` 在开了两个列表页之后会**strict-mode 撞两个** —— 隐藏 tab 的 DOM 也在文档树里（硬纪律 5）。`list-refresh.spec.ts` 改成按 routeId 收窄（`[data-tab="/_auth/system/user"] [data-testid="list-refresh"]`），并把这条写进 pages 分册，免得下一个人再踩。

## 验证

四个页面的动作行截图逐一看过（scheduler-manage / user / log-login / dept），顺序都对；全套 e2e **53 passed / 1 skipped**，`typecheck --force` · `ctx:check` · `pnpm --filter web lint` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)