### PR TITLE
feat(desktop): 打 tag 就出安装包 —— 发布这一环接上 GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+# 打 tag 发桌面端安装包。
+#
+# 为什么单独一个 workflow 而不是塞进 ci.yml：这条只在 tag 上跑、要 Windows runner、
+# 要 `contents: write`，和「每次 push 都跑的红绿信号」是两种东西。
+#
+#   git tag v0.0.1 && git push origin v0.0.1
+#
+# 跑完会在 GitHub 上留一个**草稿** release（`electron-builder.yml` 里
+# `releaseType: draft`）—— 安装包能不能装、能不能连上后端，都得人先试一遍再发布。
+#
+# 不打 tag 也能试这条流水线：Actions 里手动触发（workflow_dispatch），
+# 出的包作为 workflow artifact 上传，**不碰 release**。
+# 一条从没跑过的发布流水线，第一次跑一定是在最不该出错的时候。
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '试跑用的版本号（不发布，只出包）'
+        required: false
+        default: '0.0.0-dev'
+
+# 同一个 tag 重复推（删了重打）时，取消上一次未跑完的
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: 桌面端安装包（Windows）
+    # 必须 Windows：NSIS 安装包从 Mac/Linux 交叉打包要 Wine，不做（见 apps/desktop/README.md）
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        # windows runner 默认是 pwsh，而下面用了 `${VAR#v}` 这类 POSIX 展开
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          # 必须放在 pnpm/action-setup 之后 —— 缓存要先知道 pnpm 在哪
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # 版本号的单一来源是 tag。electron-builder 读的是 apps/desktop/package.json，
+      # 所以这里把 tag 写进去（**不提交**，只在这次构建的工作区里生效）。
+      - name: 定版本号
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VER="${GITHUB_REF_NAME#v}"
+          else
+            VER="${{ inputs.version }}"
+          fi
+          echo "value=$VER" >> "$GITHUB_OUTPUT"
+          node -e "
+            const fs = require('fs')
+            const f = 'apps/desktop/package.json'
+            const p = JSON.parse(fs.readFileSync(f, 'utf8'))
+            p.version = process.argv[1]
+            fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n')
+          " "$VER"
+          echo "桌面端版本号 → $VER"
+
+      # 🔴 tag 和界面上显示的版本必须一致。不校验的话会出现「安装包 0.0.2、
+      # 关于页面写着 v0.0.1」——而这两个数字对不上时，用户报的 bug 属于哪一版
+      # 就没人说得清了。版本的唯一真相是 brand.ts（见根 CLAUDE.md）。
+      - name: 校验 tag 与 brand.ts 一致
+        if: github.event_name == 'push'
+        run: |
+          node -e "
+            const fs = require('fs')
+            const s = fs.readFileSync('apps/web/src/lib/brand.ts', 'utf8')
+            const m = s.match(/version:\s*['\"]v?([^'\"]+)['\"]/)
+            if (!m) { console.error('brand.ts 里找不到 version 字段'); process.exit(2) }
+            const brand = m[1]
+            const tag = process.argv[1]
+            if (brand !== tag) {
+              console.error(\`不一致：brand.ts 是 v\${brand}，tag 是 v\${tag}。先改 brand.ts 再重新打 tag。\`)
+              process.exit(1)
+            }
+            console.log(\`一致：v\${brand}\`)
+          " "${{ steps.ver.outputs.value }}"
+
+      # 渲染层。⚠️ `VITE_API_BASE` 必须是空：桌面端的后端地址是**运行期配置**
+      # （userData/config.json 的 serverUrl），编译期写死会让同一个包只能连一个环境。
+      - name: 构建渲染层
+        env:
+          VITE_API_BASE: ''
+        run: pnpm --filter web build
+
+      - name: 出安装包并发到 Release（草稿）
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm --filter @admin/desktop release
+
+      - name: 只出安装包（手动试跑，不碰 release）
+        if: github.event_name == 'workflow_dispatch'
+        # 显式 `--publish never`：electron-builder 的默认发布策略是 onTagOrDraft，
+        # 不写清楚的话「手动试跑」哪天会突然把包发出去
+        run: pnpm --filter @admin/desktop package:ci
+
+      - name: 上传安装包（试跑时留个下载入口）
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-desktop-${{ steps.ver.outputs.value }}
+          path: apps/desktop/release/**/*.exe
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,27 @@ main（受保护，只能通过 PR 合入）
 > flake 也不例外：它会让一次 PR 的 CI 变红，重跑就过，不需要留档；
 > 真的反复出现，那就是一条值得**人**去写的 bug issue。
 
+## 发版
+
+版本号的唯一真相是 `apps/web/src/lib/brand.ts` 的 `version`（改名字、改版本只动那一处）。
+
+```bash
+# 1. 改 brand.ts 的 version，正常走 PR 合进 main
+# 2. 在 main 上打 tag
+git tag v0.0.1 && git push origin v0.0.1
+```
+
+tag 推上去之后：
+
+| 谁 | 做什么 |
+|---|---|
+| `.github/workflows/release.yml` | Windows runner 出桌面端 NSIS 安装包 → 传成 GitHub Release **草稿** |
+| `.github/workflows/ci.yml` 的 `build-images` | 只在 **push 到 main** 时跑，推 `latest` + `sha-<短 SHA>` 两个镜像标签；**不跟 tag** |
+
+- 🔴 **tag 和 `brand.ts` 不一致时 release 会直接失败**（故意的，见 `apps/desktop/README.md`）
+- 草稿 release 要人工确认后再发布：安装包能不能装、能不能连上后端，机器判不了
+- 想试这条流水线又不想留 tag：Actions → Release → Run workflow，出的包只作为 artifact
+
 ## 提 PR 之前
 
 这几道门必须全绿，CI 五个都跑（`static` / `eslint` / `ruff` / `pytest · SQL Server` /

--- a/apps/api/backend/core/conf.py
+++ b/apps/api/backend/core/conf.py
@@ -187,6 +187,11 @@ class Settings(BaseSettings):
         # 本项目前端 dev server（端口固定在 vite.config.ts 的 server.port）
         'http://127.0.0.1:8888',
         'http://localhost:8888',
+        # 🔴 桌面端（apps/desktop）的渲染层跑在自定义协议 `app://local` 上，
+        # 对后端就是跨源。漏了这条的表现是「桌面端装好了、页面也出来了，
+        # 但所有接口 CORS 失败」—— 和后端挂了长得一样。
+        # 它不含 localhost / 127.0.0.1，所以不会被 conf.py 末尾那条生产环境检查判成本地来源。
+        'app://local',
     ]
     CORS_EXPOSE_HEADERS: list[str] = [
         'X-Request-ID',

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -110,6 +110,41 @@ pnpm --filter @admin/desktop package        # 出 NSIS 安装包（在 Windows �
 
 > `apps/web` 一行都不用为桌面端改。浏览器版继续能单独构建、单独跑。
 
+### 发布（打 tag 走 CI）
+
+```bash
+# 1. 版本号的唯一真相是 apps/web/src/lib/brand.ts，先改它
+# 2. 打 tag 推上去
+git tag v0.0.1 && git push origin v0.0.1
+```
+
+`.github/workflows/release.yml` 会在 **windows-latest** 上出 NSIS 安装包，
+传到 GitHub Release 并留成**草稿**（`electron-builder.yml` 的 `releaseType: draft`）——
+安装包能不能装、能不能连上后端，得人先试一遍再点发布。
+
+三条要知道的：
+
+- 🔴 **tag 必须和 `brand.ts` 的 `version` 一致**，不一致 CI 直接失败。不校验的话会
+  出现「安装包 0.0.2、关于页面写着 v0.0.1」，而这两个数字对不上时，用户报的 bug
+  属于哪一版就没人说得清了。`apps/desktop/package.json` 的 `version` 由 CI 从 tag
+  写入（**不提交**）—— 它只是 electron-builder 的输入，不是第二个真相
+- **CI 出的包是未签名的、且读卡器是桩模式**（`resources/` 里没有厂商的
+  `ReadCard.exe`，那是客户现场的东西，不进仓库）。内测够用；正式交付要在能访问
+  证书的机器上打，见上面「部署时要记得的三件事」
+- **不打 tag 也能试这条流水线**：Actions → Release → Run workflow，出的包作为
+  workflow artifact 上传，**不碰 release**。一条从没跑过的发布流水线，
+  第一次跑一定是在最不该出错的时候
+
+自动更新有两个源，优先级从上到下（`src/main/updater.ts`）：
+
+| 源 | 什么时候用 | 怎么配 |
+|---|---|---|
+| generic（静态 HTTP） | 交付给内网客户 —— 他们出不去公网 | 客户机 `userData/config.json` 里填 `updateUrl` |
+| GitHub Release | 自己内测 / 开源分发 | 什么都不用配，打包时已经写进 `app-update.yml` |
+
+⚠️ 一份包同时支持两种源，不用为内网单独打一版。以前只支持第一种：没配 `updateUrl`
+就直接不检查更新，而界面显示「已是最新版本」—— 一个看不出来的假阴性。
+
 ## 渲染层怎么用
 
 ```ts
@@ -207,6 +242,13 @@ await desktop().devices.start("card-reader")
    只传 pageSize → 60.367 × 40.217mm（偏大 0.61%）；`preferCSSPageSize` + `@page` →
    59.944 × 39.878mm（偏差 0.09%）；两个都给且有 `@page` → 取准的那个。
    （Chromium 把页面尺寸量化到 1/300 英寸 = 0.24pt，做不到零误差，但能少叠一层换算误差。）
+
+**仍未验证**：
+
+- ⚠️ **发布流水线（`.github/workflows/release.yml`）没有在真 Windows runner 上跑过。**
+  它只在本地做过 YAML 解析与脚本推演；NSIS 打包、图标转换（`build/icon.png`
+  1024×1024 → ico）、上传 Release 这三步第一次真跑就是第一次打 tag。
+  想提前排掉风险就先用 workflow_dispatch 空跑一次
 
 **仍未验证（必须真硬件）**：
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -11,6 +11,10 @@ directories:
   output: release/${version}
   buildResources: build
 
+# 默认名字是 `Admin Desktop Setup 0.0.1.exe` —— 带空格的文件名进 GitHub Release
+# 下载链接会变成一串 `%20`，也不好写进部署脚本。显式压平：
+artifactName: admin-desktop-${version}-setup.${ext}
+
 # 只把主进程/preload 的产物和 package.json 打进 asar。
 # 渲染层与原生助手都走 extraResources（见下），**故意放在 asar 外面**。
 files:
@@ -59,8 +63,19 @@ nsis:
   createDesktopShortcut: true
   createStartMenuShortcut: true
 
-# 自动更新源。generic 就是一个能列目录的静态 HTTP 服务，用现成的 IIS 即可。
-# 打包时如果不需要发布，把整段注掉。
-# publish:
-#   provider: generic
-#   url: https://releases.example.com/desktop
+# ── 发布源 ──
+#
+# 这里配的是**打包时写进 `app-update.yml` 的那个源**，也就是 electron-updater
+# 默认会去问的地方。CI 打 tag 出包时 `--publish always` 会把安装包 + `latest.yml`
+# 一起传到 GitHub Release（默认建**草稿**，人工确认后再发布）。
+#
+# ⚠️ 交付给客户时通常不能用 GitHub：客户内网出不去。那时**不改这里**，
+# 在客户机的 `userData/config.json` 里填 `updateUrl` 指向内网静态服务即可 ——
+# `src/main/updater.ts` 优先用它，没填才回落到这份 app-update.yml。
+# 一份包同时支持两种升级源，不用为内网单独打一版。
+publish:
+  provider: github
+  owner: yilecoding
+  repo: fastapi-react-admin
+  # 先发草稿：安装包能不能装、能不能连上后端，都得人先试一遍
+  releaseType: draft

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,8 @@
     "dev": "node scripts/dev.mjs",
     "build": "vite build --config vite.main.config.ts && vite build --config vite.preload.config.ts",
     "package": "pnpm build && electron-builder --config electron-builder.yml",
+    "release": "pnpm build && electron-builder --config electron-builder.yml --publish always",
+    "package:ci": "pnpm build && electron-builder --config electron-builder.yml --publish never",
     "package:dir": "pnpm build && electron-builder --config electron-builder.yml --dir",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -4,10 +4,18 @@ import { app } from "electron"
 import { readConfig } from "./config"
 
 /**
- * 自动更新。用 electron-updater 的 generic provider —— 服务端只需要一个能列目录的
- * 静态 HTTP 服务(现成的 IIS 就够),不需要 GitHub Releases。
+ * 自动更新。**两个源，按优先级**：
  *
- * 惰性 import:开发模式下根本不加载它,而且没配 updateUrl 时也不必把它拉进内存。
+ * 1. `userData/config.json` 里的 `updateUrl` —— generic provider，服务端只要一个
+ *    能列目录的静态 HTTP 服务（现成的 IIS 就够）。交付给内网客户时用这个
+ * 2. 没填 `updateUrl` 就用打包时写进 `app-update.yml` 的那个源
+ *    （`electron-builder.yml` 的 `publish`，现在指向 GitHub Release）
+ *
+ * 🔴 以前只支持第 1 条：没配 `updateUrl` 就直接 `return null`，于是从 GitHub
+ * Release 装下来的包**永远查不到更新**，而界面上显示的是「已是最新版本」——
+ * 一个假阴性，看不出坏了。
+ *
+ * 惰性 import：开发模式下根本不加载它。
  */
 
 type Emit = (event: UpdaterEvent) => void
@@ -15,11 +23,12 @@ type Emit = (event: UpdaterEvent) => void
 let wired = false
 
 async function getUpdater() {
-  const { updateUrl } = readConfig()
-  if (!updateUrl) return null
-  if (!app.isPackaged) return null // 开发模式没有 app-update.yml,强跑只会报一句误导人的错
+  // 开发模式没有 app-update.yml,强跑只会报一句误导人的错
+  if (!app.isPackaged) return null
   const { autoUpdater } = await import("electron-updater")
-  autoUpdater.setFeedURL({ provider: "generic", url: updateUrl })
+  const { updateUrl } = readConfig()
+  // 填了就覆盖成内网源；没填就**不动 feed**，用打包时写进 app-update.yml 的那个
+  if (updateUrl) autoUpdater.setFeedURL({ provider: "generic", url: updateUrl })
   autoUpdater.autoDownload = true
   // 下载完不要自动重启 —— 自助终端正在给用户办业务时弹重启是事故
   autoUpdater.autoInstallOnAppQuit = true
@@ -41,7 +50,18 @@ export async function checkForUpdates(emit: Emit): Promise<void> {
     updater.on("update-downloaded", (i) => emit({ kind: "downloaded", version: i.version }))
     updater.on("error", (e) => emit({ kind: "error", message: e.message }))
   }
-  await updater.checkForUpdates()
+  try {
+    await updater.checkForUpdates()
+  } catch (e) {
+    /*
+     * 🔴 失败必须是可见状态（根 CLAUDE.md 硬纪律 9）。这里最常见的失败是
+     * **包里没有 app-update.yml**（打包时 `publish` 没配、或者用 `--dir` 出的包）——
+     * electron-updater 直接抛。让它冒到 IPC 层的话渲染端拿到的是一个 rejected
+     * promise，界面上通常什么都不显示；而 emit 一条 error，「检查更新」那一屏
+     * 至少能说出原因。
+     */
+    emit({ kind: "error", message: e instanceof Error ? e.message : String(e) })
+  }
 }
 
 export async function quitAndInstall(): Promise<void> {


### PR DESCRIPTION
## 现状盘点：外壳是完整的，缺的是「发布」

`apps/desktop` 本身该有的都有（1230 行主进程：认证托管 · 运行期服务器地址 · 设备事件流 · 静默打印 · `app://` 协议 · 自动更新），README 里还有一份逐项的「验过 / 没验」清单。但**发布这一环一步都走不通**：

| 缺什么 | 具体 |
|---|---|
| 没有出包的 CI | `ci.yml` 只有 static / eslint / ruff / pytest / e2e / pages / GHCR 镜像，桌面端只进了 `pnpm typecheck` |
| `publish` 是注释掉的 | `electron-builder.yml` 里那段 generic 全被注释，`--publish` 无从下手 |
| 版本号三处不一致 | root `package.json` 0.0.0 · `apps/desktop/package.json` 0.0.0 · `brand.ts` **v0.0.1** |
| 更新器只认内网源 | 见下面「顺手修的两个坑」 |
| 产物名带空格 | 默认 `Admin Desktop Setup 0.0.1.exe` → Release 下载链接一串 `%20` |

## 改了什么

- **新增 `.github/workflows/release.yml`**：push `v*` tag → windows-latest 出 NSIS → 传成 GitHub Release **草稿**（`releaseType: draft`，安装包能不能装、能不能连后端，机器判不了）。单独一个 workflow 而不是塞进 `ci.yml`：它只在 tag 上跑、要 Windows runner、要 `contents: write`
- **版本号从 tag 注入** `apps/desktop/package.json`（**不提交**）。它只是 electron-builder 的输入，不是第二个真相 —— 唯一真相仍是 `brand.ts`
- 🔴 **tag 与 `brand.ts` 不一致直接失败**。不校验会出现「安装包 0.0.2、关于页写着 v0.0.1」，两个数字对不上时用户报的 bug 属于哪一版就说不清了
- **不打 tag 也能试**：`workflow_dispatch` 只出包 + 上传 artifact，不碰 release。为此加了 `package:ci`（显式 `--publish never`）—— electron-builder 默认策略是 `onTagOrDraft`，不写清楚哪天会把手动试跑的包发出去
- `artifactName: admin-desktop-${version}-setup.${ext}`

## 顺手修的两个「装了才发现」的坑

1. 🔴 **`updater.ts` 以前只支持 generic 源**：没配 `updateUrl` 就 `return null` → 从 GitHub Release 装下来的包**永远查不到更新**，而界面显示「已是最新版本」。假阴性，看不出坏了。现在两个源按优先级：填了 `updateUrl` 用内网静态服务（客户出不去公网），没填就用打包时写进 `app-update.yml` 的那个 —— **一份包同时支持两种升级源**，不用为内网单独打一版。顺带把 `checkForUpdates()` 的异常接住 emit 成 error（以前是 rejected promise，界面上什么都不显示）
2. 🔴 **`CORS_ALLOWED_ORIGINS` 补 `app://local`**：桌面端渲染层跑在自定义协议上，对后端就是跨源。README 的部署清单里写着这条，代码里一直没加 —— 漏了的表现是「桌面端装好了、页面也出来了，但所有接口 CORS 失败」，和后端挂了长得一样。`backend/app/admin/tests/security/test_prod_config.py` 17 条本地跑过，不受影响（那条生产检查只拦 localhost / 127.0.0.1 / `*`）

## 已知前提（写进 README 了，不是遗漏）

- CI 出的包**未签名**，Windows SmartScreen 会拦；正式交付要在能访问证书的机器上打（README 里那条实测：不签名的话杀软首次扫 `ReadCard.exe` 会让用户第一次刷卡等 17.9 秒）
- CI 出的包里**读卡器是桩模式** —— `resources/` 里没有厂商的 `ReadCard.exe`，那是客户现场的东西，不进仓库
- ⚠️ **这条流水线没在真 Windows runner 上跑过**（本地只做了 YAML 解析和脚本推演）。NSIS 打包、图标转换（`build/icon.png` 1024×1024 → ico）、上传 Release 三步第一次真跑就是第一次打 tag。**建议先 workflow_dispatch 空跑一次**，我在 README 的「现状」清单里也照实记了这条

## 文档

`apps/desktop/README.md` 补「发布」一节（含两个升级源的对照表）；`CONTRIBUTING.md` 补「发版」一节（版本改 `brand.ts` → 打 tag → 草稿 release → 人工确认；顺带说明镜像那条只跟 main 不跟 tag）。

> ⚠️ 工作区里同时有 #30 的后端改动（读接口 RBAC），**没有**进这次提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)