### PR TITLE
fix(release): 试跑产物收窄到安装包本体，并允许预发布 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,15 @@ jobs:
             if (!m) { console.error('brand.ts 里找不到 version 字段'); process.exit(2) }
             const brand = m[1]
             const tag = process.argv[1]
-            if (brand !== tag) {
+            // 允许预发布后缀：brand.ts 是 0.0.1 时，v0.0.1 与 v0.0.1-rc.1 都算一致。
+            // 不允许的话「发到 Release 那一步」就只能拿正式版去试 —— 而那一步恰恰是
+            // 整条流水线里唯一没法本地验证的（要真的往仓库写一个 release）
+            const ok = brand === tag || tag.startsWith(brand + '-')
+            if (!ok) {
               console.error(\`不一致：brand.ts 是 v\${brand}，tag 是 v\${tag}。先改 brand.ts 再重新打 tag。\`)
               process.exit(1)
             }
-            console.log(\`一致：v\${brand}\`)
+            console.log(\`一致：brand.ts v\${brand} ← tag v\${tag}\`)
           " "${{ steps.ver.outputs.value }}"
 
       # 渲染层。⚠️ `VITE_API_BASE` 必须是空：桌面端的后端地址是**运行期配置**
@@ -117,5 +121,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: admin-desktop-${{ steps.ver.outputs.value }}
-          path: apps/desktop/release/**/*.exe
+          # 只要安装包本体 + blockmap（差量更新用）。写 `**/*.exe` 会把
+          # win-unpacked 里的 admin-desktop.exe / elevate.exe 一起卷进来 ——
+          # 实测 artifact 从 ~90MB 涨到 195MB，而那些文件下载下来没用
+          path: |
+            apps/desktop/release/*/*setup.exe
+            apps/desktop/release/*/*setup.exe.blockmap
           if-no-files-found: error

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -131,9 +131,11 @@ git tag v0.0.1 && git push origin v0.0.1
 - **CI 出的包是未签名的、且读卡器是桩模式**（`resources/` 里没有厂商的
   `ReadCard.exe`，那是客户现场的东西，不进仓库）。内测够用；正式交付要在能访问
   证书的机器上打，见上面「部署时要记得的三件事」
-- **不打 tag 也能试这条流水线**：Actions → Release → Run workflow，出的包作为
-  workflow artifact 上传，**不碰 release**。一条从没跑过的发布流水线，
-  第一次跑一定是在最不该出错的时候
+- **两种试跑方式**（一条从没跑过的发布流水线，第一次跑一定是在最不该出错的时候）：
+  - Actions → Release → Run workflow：只出包 + 上传成 workflow artifact，**不碰 release**
+  - 打个预发布 tag（`v0.0.1-rc.1`）：**把「发到 Release」那一步也走一遍** ——
+    这是整条流水线里唯一没法本地验证的部分。版本校验允许预发布后缀，
+    `brand.ts` 是 0.0.1 时 `v0.0.1-rc.1` 算一致
 
 自动更新有两个源，优先级从上到下（`src/main/updater.ts`）：
 


### PR DESCRIPTION
在真 Windows runner 上空跑了一次 #40 的流水线（[run](https://github.com/yilecoding/fastapi-react-admin/actions/runs/32965912934)，2.5 分钟）——打包这一半是通的：

```
• packaging       platform=win32 arch=x64 electron=42.9.3
• building        target=nsis file=release\0.0.0-dev\admin-desktop-0.0.0-dev-setup.exe oneClick=false perMachine=true
• building block map
```

`artifactName` 生效、blockmap 也有。抓到两个小问题：

1. **上传的 artifact 195MB** —— `**/*.exe` 把 `win-unpacked/` 里的 `admin-desktop.exe` / `elevate.exe` 一起卷进来了，下载下来没用。收窄成 `*setup.exe` + `.blockmap`
2. **版本校验只认完全相等**，于是「发到 GitHub Release」那一步只能拿正式版去试 —— 而它恰恰是整条流水线里唯一没法本地验证的一步（要真往仓库写一个 release）。改成允许预发布后缀：`brand.ts` 是 `0.0.1` 时，`v0.0.1` 与 `v0.0.1-rc.1` 都算一致

于是发 0.0.1 之前可以先 `git tag v0.0.1-rc.1` 把发布那一步也验一遍，草稿 release 试完删掉即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)