### PR TITLE
fix(desktop): 打包发布收口 —— 两个只在正式包里才炸的更新 bug + per-user 安装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@
 | 动定时任务 / Celery / 调度 | [`apps/api/backend/app/task/AGENTS.md`](apps/api/backend/app/task/AGENTS.md) |
 | 动命令面板 / 快捷键 | [`packages/platform/src/shell/AGENTS.md`](packages/platform/src/shell/AGENTS.md) |
 | 动构建注入 / 发版提示 / 错误页 | [`apps/web/AGENTS.md`](apps/web/AGENTS.md) |
+| **桌面端打包 / 发版 / 自动更新** | [`apps/desktop/AGENTS.md`](apps/desktop/AGENTS.md) |
 | 写或跑前端 E2E | [`apps/web/e2e/AGENTS.md`](apps/web/e2e/AGENTS.md) |
 | 动菜单 / 权限 / 死链判定 | 硬纪律 6 + [`pages/menu/AGENTS.md`](packages/platform/src/pages/menu/AGENTS.md) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ tag 推上去之后：
 - 🔴 **tag 和 `brand.ts` 不一致时 release 会直接失败**（故意的，见 `apps/desktop/README.md`）
 - 草稿 release 要人工确认后再发布：安装包能不能装、能不能连上后端，机器判不了
 - 想试这条流水线又不想留 tag：Actions → Release → Run workflow，出的包只作为 artifact
+- 桌面端出包 / 分发 / 自动更新的坑收在 [`apps/desktop/AGENTS.md`](apps/desktop/AGENTS.md)
 
 ## 提 PR 之前
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,0 +1,141 @@
+# apps/desktop 的打包与发布
+
+> 外壳本身怎么用见 [`README.md`](./README.md)。这一份只讲**出包与发版** ——
+> 全是「做错了不当场报错」的那类结论，多数**只在正式包里才撞得到**。
+>
+> 这份文件是根 `CLAUDE.md` 的**模块分册**，Claude Code 在你读到本目录下的文件时
+> 才把它加载进上下文（惰性加载）。跨模块的硬纪律仍然只在根 `CLAUDE.md` 里有一份。
+
+## 出包的顺序：漏了第一步不报错，只是界面是上一版的
+
+```bash
+pnpm --filter web build                  # ① 渲染层
+pnpm --filter @admin/desktop package     # ② 主进程 + preload + NSIS → release/<版本>/
+```
+
+🔴 **①不能省，而且它不在 desktop 自己的 `build` 里。** desktop 的 `build` 只编主进程和
+preload；渲染层是 `electron-builder.yml` 的 `extraResources` 从 `apps/web/dist` **抓的**。
+漏了①的两种表现都不指向「忘了构建前端」：
+
+| 情况 | 表现 |
+|---|---|
+| `apps/web/dist` 不存在 | 报一个 file source 不存在（还算能查） |
+| 存在但是旧的 | **包出来界面是上一版的，不报任何错** |
+
+CI 的 `release.yml` 里这两步是写死的顺序，本地手打包要自己记住。
+（`turbo` 的 `@admin/desktop#build` 声明了 `dependsOn: web#build`，所以走
+`pnpm build` 也对；但 `pnpm --filter @admin/desktop package` **不经过** turbo 那条依赖。）
+
+## 发布的两条路线
+
+| | 用在哪 | 产物去哪 |
+|---|---|---|
+| **A. GitHub Release**（本仓库默认） | 开源分发 / 自己内测 | 打 `v*` tag → `.github/workflows/release.yml` → 草稿 release |
+| **B. 内网静态目录** | 交付给出不去公网的客户 | 人工/脚本把三个文件放进一个能列目录的 HTTP 目录（IIS、nginx 都行） |
+
+两条路线**用的是同一个安装包**，区别只在「更新源指向哪」（见下一节）。
+
+### B 路线要放的是**三个**文件，且有顺序
+
+```
+<版本>.exe          安装包本体
+<版本>.exe.blockmap 差量更新用（少了它每次都是全量下载）
+latest.yml          更新端要读的清单
+```
+
+🔴 **`latest.yml` 必须最后放。** 它先落地的话，中间那几秒里客户端会拿到 404 或者
+半个包 —— 而这两种都不报「更新源没准备好」，只报一个下载失败。
+
+⚠️ **`latest.yml` 那一层不能缓存**（nginx / IIS 都要显式关）。缓存住的表现是
+「发了新版但客户端永远说已是最新」—— 和第 1 节那条一样，是个静默的假阴性。
+
+## 更新源：编译期只是默认值，运行期可以逐台覆盖
+
+`electron-builder.yml` 的 `publish` 段决定**打包时写进 `app-update.yml` 的那个源**；
+`src/main/updater.ts` 启动时如果读到 `userData/config.json` 的 `updateUrl`，
+就 `setFeedURL` 覆盖成 generic。所以：
+
+- 同一个安装包发到不同部署点，更新源可以逐台机器不同
+- 交付内网客户时**不用为它单独打一版**，改客户机的 `config.json` 即可
+
+🔴 **`publish` 段不能注掉。** 它不只是「发布」用的：有它 electron-builder 才会
+① 生成 `latest.yml` ② 把 `app-update.yml` 打进包里的 `resources/`。
+注掉之后打出来的包，产物目录里没有 `latest.yml`、`resources/` 里没有 `app-update.yml`，
+表现是**点检查更新直接报错**，而错误信息跟「打包配置」毫无关系。
+
+## 四个坑，两个只在正式包里撞得到
+
+### 🔴 1. `await import("electron-updater")` 在正式包里拿到的是 undefined
+
+electron-updater 是 CommonJS，而主进程产物是 vite 打的 cjs bundle —— 这条路径上
+`import()` 回的是 `{ default: { autoUpdater } }`。要 `mod.autoUpdater ?? mod.default?.autoUpdater`
+两边都认。
+
+⚠️ **开发模式永远撞不到**：`getUpdater()` 在 `!app.isPackaged` 时早退，根本不加载那个模块。
+正式包里的表现是 `Cannot read properties of undefined (reading 'setFeedURL')`。
+
+### 🔴 2. `quitAndInstall()` 默认**不是**静默安装
+
+NSIS 是 `oneClick: false`（带向导，好处是首次安装能选目录），而 `quitAndInstall()` 的
+`isSilent` 默认 `false` —— 两者一撞，拉起来的是**交互式安装向导**：应用退了、新版本没装上、
+停在「下一步」等人点。无人值守的终端机上没人会去点。必须显式 `quitAndInstall(true, true)`。
+
+判据（在自己的落盘日志里就能看到）：
+
+```
+Install: isSilent: false, isForceRunAfter: true
+Update installer has already been triggered. Quitting application.
+```
+
+之后 exe 仍然是旧版本。
+
+### 🔴 3. `perMachine` 是为自动更新选的，不是随手填的
+
+`perMachine: false`（装进 `%LOCALAPPDATA%\Programs`）—— per-machine 装进 Program Files，
+每次更新都要 UAC 提权，而终端机操作员通常不是管理员，静默更新会卡在提权对话框上。
+
+⚠️ 机器上如果**还留着**早先 per-machine 装的那一份（同一个 `appId`），注册表 `HKLM`
+的卸载项会让安装器仍然去更新旧位置 → 又要提权 → 静默失败。判据：卸载项的
+`UninstallString` 带 `/allusers`，先卸掉再装新包。
+
+### ⚠️ 4. 增量下载第一次通常回落成全量
+
+`.blockmap` 让 electron-updater 只下差异块，但它要拿**本机那个旧安装包**的 blockmap 去比。
+第一次更新常报 `Cannot download differentially, fallback to full download: sha512 checksum
+mismatch` —— 不是故障，是本机没有匹配的旧包。之后的更新才吃到增量。
+
+## 环境坑
+
+### ⚠️ `EPERM: rename win-unpacked.tmp -> win-unpacked` 是杀软，不是构建配置
+
+`package` 在解包 Electron 之后倒在 `rename('win-unpacked.tmp' → 'win-unpacked')`，
+而目标目录**并不存在** —— 所以不是「目录已存在」那类问题。
+
+按这个顺序查能直接指到人：手工删那个 `.tmp` → 报 `default_app.asar` 正被占用 →
+进程列表里找不到持有者 → 查 `root/SecurityCenter2` 的 AntiVirusProduct。
+真凶是企业级 AV 的实时防护抓着刚落盘的两百多 MB Electron 二进制不放（`.asar` 是压缩包，
+它要扫），而它的句柄不带 share-delete，于是 rename 和 delete 都失败。
+
+修法按代价排：给 AV 加排除（release 输出目录 + `%LOCALAPPDATA%\electron\Cache` +
+`%LOCALAPPDATA%\electron-builder\Cache`，唯一的真修法）→ 重启后重跑（AV 按哈希缓存信誉，
+第二次常常能过）→ 换一台没装那套 AV 的机器 / CI。
+
+⚠️ 别去 kill 那个 AV 进程：企业策略里通常有防篡改，杀不掉还会上报。
+
+### ⚠️ 更新缓存目录叫 `@admindesktop-updater`
+
+electron-builder 从 `package.json` 的 `name`（`@admin/desktop`）推出来的，**不跟
+`productName` 走**。它只是下载缓存，不影响功能 —— 看到这个名字别以为装错了应用。
+
+### ⚠️ 未签名包的第一次启动会很慢
+
+不签名的话，AV 首次扫描新 exe 的开销会落在用户的第一次操作上。正式交付要在能访问
+证书的机器上打包并配 `signtoolOptions`（`electron-builder.yml` 里留了注释位）。
+
+## 三个「发版之后就不能改」的值
+
+`appId` · `productName` · `executableName`（`electron-builder.yml` 顶部）。
+`productName` 同时是 `%APPDATA%\<它>\config.json` 的目录名 —— 改名 = 老机器上的
+服务器地址 / 打印机名 / 更新源全成孤儿，表现为「更新完又要重填一遍」而不是报错；
+`appId` 是 Windows 认「同一个应用的升级」的依据，改了会装出两份并存。
+**接新项目时第一件事就是改掉它们，且要在第一次发版之前改完。**

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -118,34 +118,18 @@ pnpm --filter @admin/desktop package        # 出 NSIS 安装包（在 Windows �
 git tag v0.0.1 && git push origin v0.0.1
 ```
 
-`.github/workflows/release.yml` 会在 **windows-latest** 上出 NSIS 安装包，
-传到 GitHub Release 并留成**草稿**（`electron-builder.yml` 的 `releaseType: draft`）——
-安装包能不能装、能不能连上后端，得人先试一遍再点发布。
+`.github/workflows/release.yml` 在 **windows-latest** 上出 NSIS 安装包，传到 GitHub
+Release 并留成**草稿** —— 安装包能不能装、能不能连上后端，得人先试一遍再点发布。
 
-三条要知道的：
+- 🔴 **tag 必须和 `brand.ts` 的 `version` 一致**，不一致 CI 直接失败（允许预发布后缀：
+  `brand.ts` 是 0.0.1 时 `v0.0.1-rc.1` 也算一致，专门留给「试一次发布」用）。
+  `apps/desktop/package.json` 的 `version` 由 CI 从 tag 写入（**不提交**）——
+  它只是 electron-builder 的输入，不是第二个真相
+- **不打 tag 也能试**：Actions → Release → Run workflow，只出包 + 上传 artifact，不碰 release
 
-- 🔴 **tag 必须和 `brand.ts` 的 `version` 一致**，不一致 CI 直接失败。不校验的话会
-  出现「安装包 0.0.2、关于页面写着 v0.0.1」，而这两个数字对不上时，用户报的 bug
-  属于哪一版就没人说得清了。`apps/desktop/package.json` 的 `version` 由 CI 从 tag
-  写入（**不提交**）—— 它只是 electron-builder 的输入，不是第二个真相
-- **CI 出的包是未签名的、且读卡器是桩模式**（`resources/` 里没有厂商的
-  `ReadCard.exe`，那是客户现场的东西，不进仓库）。内测够用；正式交付要在能访问
-  证书的机器上打，见上面「部署时要记得的三件事」
-- **两种试跑方式**（一条从没跑过的发布流水线，第一次跑一定是在最不该出错的时候）：
-  - Actions → Release → Run workflow：只出包 + 上传成 workflow artifact，**不碰 release**
-  - 打个预发布 tag（`v0.0.1-rc.1`）：**把「发到 Release」那一步也走一遍** ——
-    这是整条流水线里唯一没法本地验证的部分。版本校验允许预发布后缀，
-    `brand.ts` 是 0.0.1 时 `v0.0.1-rc.1` 算一致
-
-自动更新有两个源，优先级从上到下（`src/main/updater.ts`）：
-
-| 源 | 什么时候用 | 怎么配 |
-|---|---|---|
-| generic（静态 HTTP） | 交付给内网客户 —— 他们出不去公网 | 客户机 `userData/config.json` 里填 `updateUrl` |
-| GitHub Release | 自己内测 / 开源分发 | 什么都不用配，打包时已经写进 `app-update.yml` |
-
-⚠️ 一份包同时支持两种源，不用为内网单独打一版。以前只支持第一种：没配 `updateUrl`
-就直接不检查更新，而界面显示「已是最新版本」—— 一个看不出来的假阴性。
+🔴 **打包顺序、两条分发路线（GitHub Release / 内网静态目录）、自动更新那四个
+「只在正式包里才撞得到」的坑、以及杀软导致的 EPERM，全部收在
+[`AGENTS.md`](./AGENTS.md)。** 出包或发版之前先读那一份 —— 这里列的命令只是入口。
 
 ## 渲染层怎么用
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,6 +1,12 @@
 # electron-builder 配置。`pnpm --filter @admin/desktop package` 触发。
 # ⚠️ 发自己的包前改成你自己的反向域名 —— macOS 靠它认应用身份，
 #    Windows 靠它认「同一个应用的升级」。沿用别人的会和别人的安装冲突
+# 🔴 这三个值一起决定「装出来叫什么」，而且**发版之后就不能再改**：
+#   productName 同时是 `%APPDATA%\<它>\config.json` 的目录名（服务器地址、
+#     打印机名、更新源都在里面）—— 改名 = 老机器上的配置成孤儿，
+#     表现为「更新完之后又要重填一遍」，而不是一个报错；
+#   appId 是 Windows 认「同一个应用的升级」的依据，改了会装出两份并存；
+#   executableName 会出现在路径、任务管理器和脚本里，保持 ASCII 小写。
 appId: io.github.yilecoding.admin-desktop
 productName: Admin Desktop
 # 不设的话 Linux 下可执行文件名会从包名推出来，变成 `@admindesktop`（实测）
@@ -58,7 +64,20 @@ linux:
 
 nsis:
   oneClick: false
-  perMachine: true
+  # 🔴 **per-user 安装（装进 %LOCALAPPDATA%\Programs），不是 per-machine。**
+  #
+  # 这一条是为**自动更新**选的：per-machine 装进 Program Files，每次更新都要 UAC 提权，
+  # 而终端机的操作员通常不是管理员 —— 静默更新会卡在提权对话框上，
+  # 而那台机器的窗口往往是无边框全屏的，对话框未必看得见。
+  # VS Code 的 User Setup 走的就是这条路。
+  #
+  # ⚠️ 代价：**每个 Windows 账号各装一份**。单账号长期登录的终端机代价是零；
+  # 多账号轮用的场景要回头重新评估。
+  # ⚠️ 改这一项等于改安装位置，发版之后再改会留下两份并存 —— 趁没发出去定死。
+  # ⚠️ 更阴的一条：机器上如果**还留着**早先 per-machine 装的那一份（同一个 appId），
+  # 注册表 HKLM 的卸载项会让安装器仍然去更新旧位置 → 又要提权 → 静默更新失败。
+  # 判据：卸载项里那条的 `UninstallString` 带 `/allusers`，先卸掉再装新包。
+  perMachine: false
   allowToChangeInstallationDirectory: true
   createDesktopShortcut: true
   createStartMenuShortcut: true

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -25,7 +25,23 @@ let wired = false
 async function getUpdater() {
   // 开发模式没有 app-update.yml,强跑只会报一句误导人的错
   if (!app.isPackaged) return null
-  const { autoUpdater } = await import("electron-updater")
+  /*
+   * 🔴 `const { autoUpdater } = await import(...)` 在**正式包里拿到的是 undefined**。
+   *
+   * electron-updater 是 CommonJS，而主进程产物是 vite 打的 cjs bundle ——
+   * 这条路径上 `import()` 回的是 `{ default: { autoUpdater } }`。两边都认才行。
+   *
+   * ⚠️ **开发模式永远撞不到这个 bug**：上面 `!app.isPackaged` 就早退了，
+   * 根本不加载这个模块。正式包里的表现是
+   * `Cannot read properties of undefined (reading 'setFeedURL')`。
+   * （实测：下游项目的 0.0.x 正式包，2026-08-25）
+   */
+  const mod = (await import("electron-updater")) as unknown as {
+    autoUpdater?: typeof import("electron-updater").autoUpdater
+    default?: { autoUpdater?: typeof import("electron-updater").autoUpdater }
+  }
+  const autoUpdater = mod.autoUpdater ?? mod.default?.autoUpdater
+  if (!autoUpdater) return null
   const { updateUrl } = readConfig()
   // 填了就覆盖成内网源；没填就**不动 feed**，用打包时写进 app-update.yml 的那个
   if (updateUrl) autoUpdater.setFeedURL({ provider: "generic", url: updateUrl })
@@ -66,5 +82,18 @@ export async function checkForUpdates(emit: Emit): Promise<void> {
 
 export async function quitAndInstall(): Promise<void> {
   const updater = await getUpdater()
-  updater?.quitAndInstall()
+  /*
+   * 🔴 必须显式 `(true, true)` = 静默安装 + 装完自动拉回来。
+   *
+   * `quitAndInstall()` 的 `isSilent` 默认是 `false`，而我们的 NSIS 是
+   * `oneClick: false`（带向导，好处是首次安装能选目录）—— 两者一撞，
+   * 拉起来的是**交互式安装向导**：应用退了、新版本没装上、界面上停在
+   * 「下一步」等人点。自助终端/无人值守的机器上没人会去点。
+   *
+   * 实测判据（下游项目 2026-08-25 的落盘日志）：
+   *   Install: isSilent: false, isForceRunAfter: true
+   *   Update installer has already been triggered. Quitting application.
+   * 之后 exe 仍然是旧版本 —— 安装器起来了，停在向导上。
+   */
+  updater?.quitAndInstall(true, true)
 }

--- a/scripts/ctx-check.mjs
+++ b/scripts/ctx-check.mjs
@@ -88,6 +88,12 @@ const ALLOW = new Map(Object.entries({
   'settings-layout.tsx': '已被 settings-shell.tsx 取代，文档在讲换掉它的理由',
   'command.tsx': 'cmdk 封装，零调用方已连依赖链一起删除；文档在讲「不要把它引回来」',
   'version.json': '构建产物（vite 发到 dist 根目录），不进 git',
+  'latest.yml': 'electron-builder 的产物（更新清单），不进 git',
+  'app-update.yml': '同上，打包时写进安装包的 resources/',
+  'userData/config.json': '桌面端运行期在用户目录生成的配置',
+  'config.json': '同上',
+  'resources/': '桌面端放原生助手的目录，仓库里只有一个 .gitkeep —— 而这个扫描器跳过点开头的文件',
+  'release.yml': '在 .github/ 下，而这个扫描器刻意跳过点开头的目录',
 }))
 
 /** 章节标题 → 所在上下文文件。用来判「见「XXX」」指的那一节还在不在、在不在同一份 */


### PR DESCRIPTION
对着一个**已经发到 0.0.13 的下游项目**（同一套外壳，13 个正式包 + 一整轮更新链路跑通）逐条比对了打包发布配置。抓到两个我们这边一样存在、**但开发模式永远撞不到**的 bug。

## 🔴 1. `await import("electron-updater")` 在正式包里拿到的是 undefined

electron-updater 是 CommonJS，而主进程产物是 vite 打的 cjs bundle —— 这条路径上 `import()` 回的是 `{ default: { autoUpdater } }`。现在 `mod.autoUpdater ?? mod.default?.autoUpdater` 两边都认。

⚠️ **开发模式撞不到**：`getUpdater()` 在 `!app.isPackaged` 时早退，根本不加载那个模块。正式包里的表现是 `Cannot read properties of undefined (reading 'setFeedURL')` —— 一句和「打包配置」毫无关系的错。

## 🔴 2. `quitAndInstall()` 默认不是静默安装

我们的 NSIS 是 `oneClick: false`（带向导，好处是首次安装能选目录），而 `quitAndInstall()` 的 `isSilent` 默认 `false` —— 两者一撞，拉起来的是**交互式安装向导**：应用退了、新版本没装上、停在「下一步」等人点。无人值守的终端机上没人会去点。

下游的落盘日志（判据就在自己的日志里）：

```
Install: isSilent: false, isForceRunAfter: true
Update installer has already been triggered. Quitting application.
```

之后 exe 仍然是旧版本。改成显式 `quitAndInstall(true, true)`（静默 + 装完自动拉回来）。

## 🔴 3. 安装方式改成 per-user（`perMachine: false`）

per-machine 装进 `Program Files`，**每次更新都要 UAC 提权**，而终端机操作员通常不是管理员 —— 静默更新会卡在提权对话框上，而那类机器的窗口往往是无边框全屏的，对话框未必看得见。VS Code 的 User Setup 走的就是这条。

- 代价：每个 Windows 账号各装一份（单账号长期登录的终端机代价是零）
- ⚠️ **趁还没发第一版定死**：改安装位置在发版之后做会留下两份并存
- ⚠️ 更阴的一条已写进分册：机器上若**还留着**早先 per-machine 装的那份（同一 `appId`），`HKLM` 的卸载项会让安装器仍去更新旧位置 → 又要提权 → 静默失败。判据是 `UninstallString` 带 `/allusers`

## 新增 `apps/desktop/AGENTS.md`（打包与发布分册）

README 只留操作命令，坑全部收进分册，避免两份漂移：

- **出包顺序**：漏了 `pnpm --filter web build` 不报错，**只是包里界面是上一版的**（`extraResources` 从 `apps/web/dist` 抓，desktop 自己的 `build` 只编主进程）
- **两条分发路线**：GitHub Release（本仓库默认）/ 内网静态目录（三个文件，且 `latest.yml` **必须最后放** —— 先放的话中间几秒客户端拿到 404 或半个包；那一层还不能缓存）
- **更新源**：编译期 `publish` 只是默认值，运行期 `config.json` 的 `updateUrl` 覆盖 → 同一个包发到不同部署点，更新源逐台不同
- **`publish` 段不能注掉**：没有它就不生成 `latest.yml`、不打 `app-update.yml` 进包
- **增量下载第一次会回落成全量**（本机没有匹配的旧包 blockmap），不是故障
- **`EPERM: rename win-unpacked.tmp` 是杀软不是构建配置**，附按代价排序的定位步骤
- **三个发版后不能改的值**：`appId` / `productName`（同时是 `%APPDATA%\<它>\config.json` 的目录名，改名 = 老机器配置成孤儿）/ `executableName`

根 CLAUDE.md 导航表加了一行；`ctx-check` 的 ALLOW 表登记了 `latest.yml` / `app-update.yml` / `config.json` 这类运行期产物（不在 git 里，正是文档要讲的那种东西）。

> 本次不含读卡器相关内容 —— 那块按用户要求先放一边，分册里也没有把它写成发版的必经步骤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)