### PR TITLE
feat(release): 三个平台一起出包 —— Windows / macOS / Linux，外加一份像样的发布说明

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
-# 打 tag 发桌面端安装包。
-#
-# 为什么单独一个 workflow 而不是塞进 ci.yml：这条只在 tag 上跑、要 Windows runner、
-# 要 `contents: write`，和「每次 push 都跑的红绿信号」是两种东西。
+# 打 tag 发桌面端安装包（三个平台）。
 #
 #   git tag v0.0.1 && git push origin v0.0.1
 #
-# 跑完会在 GitHub 上留一个**草稿** release（`electron-builder.yml` 里
-# `releaseType: draft`）—— 安装包能不能装、能不能连上后端，都得人先试一遍再发布。
+# 跑完会在 GitHub 上留一个**草稿** release，人工确认后再发布 —— 安装包能不能装、
+# 能不能连上后端，机器判不了。
 #
-# 不打 tag 也能试这条流水线：Actions 里手动触发（workflow_dispatch），
-# 出的包作为 workflow artifact 上传，**不碰 release**。
-# 一条从没跑过的发布流水线，第一次跑一定是在最不该出错的时候。
+# 不打 tag 也能试：Actions → Release → Run workflow，产物作为 workflow artifact
+# 上传，**不碰 release**。一条从没跑过的发布流水线，第一次跑一定是在最不该出错的时候。
 name: Release
 
 on:
@@ -24,16 +20,77 @@ on:
         required: false
         default: '0.0.0-dev'
 
-# 同一个 tag 重复推（删了重打）时，取消上一次未跑完的
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  desktop:
-    name: 桌面端安装包（Windows）
-    # 必须 Windows：NSIS 安装包从 Mac/Linux 交叉打包要 Wine，不做（见 apps/desktop/README.md）
-    runs-on: windows-latest
+  # 🔴 草稿必须**先建好、且只建一次**。三个平台的 job 同时跑，谁都去建的话就会
+  # 撞出多个草稿 —— GitHub 的草稿不按 tag 去重，实测踩过（v0.0.1-rc.1 当场劈成两个，
+  # 一个只有 blockmap、另一个有 exe，而那次运行还是「成功」）。
+  prepare:
+    name: 建草稿 Release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 校验 tag 与 brand.ts 一致
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          node -e "
+            const fs = require('fs')
+            const s = fs.readFileSync('apps/web/src/lib/brand.ts', 'utf8')
+            const m = s.match(/version:\s*['\"]v?([^'\"]+)['\"]/)
+            if (!m) { console.error('brand.ts 里找不到 version 字段'); process.exit(2) }
+            const brand = m[1]
+            const tag = process.argv[1]
+            // 允许预发布后缀：brand.ts 是 0.0.1 时 v0.0.1 与 v0.0.1-rc.1 都算一致。
+            // 「发到 Release」那一步没法本地验证，得留个能试的口子
+            if (!(brand === tag || tag.startsWith(brand + '-'))) {
+              console.error(\`不一致：brand.ts 是 v\${brand}，tag 是 v\${tag}。先改 brand.ts 再重新打 tag。\`)
+              process.exit(1)
+            }
+            console.log(\`一致：brand.ts v\${brand} ← tag v\${tag}\`)
+          " "$VER"
+
+      - name: 建草稿（已存在就跳过）
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "草稿已存在，复用"
+          else
+            gh release create "$GITHUB_REF_NAME" --draft \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file apps/desktop/release-notes.md \
+              --generate-notes
+          fi
+
+  build:
+    name: ${{ matrix.label }}
+    needs: [prepare]
+    # 试跑（workflow_dispatch）时 prepare 被 if 跳过，这里要显式放行
+    if: always() && (needs.prepare.result == 'success' || github.event_name == 'workflow_dispatch')
+    strategy:
+      # 一个平台挂了不要连坐 —— 另外两个的包仍然值得拿到
+      fail-fast: false
+      matrix:
+        include:
+          # 🔴 每个平台只能在自己的机器上打：mac 的 dmg 要 macOS 工具链，
+          # Windows 的 nsis 从 mac/linux 交叉打要 Wine（不做）
+          - os: windows-latest
+            label: Windows（NSIS 安装包）
+            glob: 'apps/desktop/release/*/*.exe'
+          - os: macos-latest
+            label: macOS（dmg + zip，arm64 / x64）
+            glob: 'apps/desktop/release/*/*.dmg apps/desktop/release/*/*.zip'
+          - os: ubuntu-latest
+            label: Linux（AppImage）
+            glob: 'apps/desktop/release/*/*.AppImage'
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     defaults:
@@ -73,30 +130,6 @@ jobs:
           " "$VER"
           echo "桌面端版本号 → $VER"
 
-      # 🔴 tag 和界面上显示的版本必须一致。不校验的话会出现「安装包 0.0.2、
-      # 关于页面写着 v0.0.1」——而这两个数字对不上时，用户报的 bug 属于哪一版
-      # 就没人说得清了。版本的唯一真相是 brand.ts（见根 CLAUDE.md）。
-      - name: 校验 tag 与 brand.ts 一致
-        if: github.event_name == 'push'
-        run: |
-          node -e "
-            const fs = require('fs')
-            const s = fs.readFileSync('apps/web/src/lib/brand.ts', 'utf8')
-            const m = s.match(/version:\s*['\"]v?([^'\"]+)['\"]/)
-            if (!m) { console.error('brand.ts 里找不到 version 字段'); process.exit(2) }
-            const brand = m[1]
-            const tag = process.argv[1]
-            // 允许预发布后缀：brand.ts 是 0.0.1 时，v0.0.1 与 v0.0.1-rc.1 都算一致。
-            // 不允许的话「发到 Release 那一步」就只能拿正式版去试 —— 而那一步恰恰是
-            // 整条流水线里唯一没法本地验证的（要真的往仓库写一个 release）
-            const ok = brand === tag || tag.startsWith(brand + '-')
-            if (!ok) {
-              console.error(\`不一致：brand.ts 是 v\${brand}，tag 是 v\${tag}。先改 brand.ts 再重新打 tag。\`)
-              process.exit(1)
-            }
-            console.log(\`一致：brand.ts v\${brand} ← tag v\${tag}\`)
-          " "${{ steps.ver.outputs.value }}"
-
       # 渲染层。⚠️ `VITE_API_BASE` 必须是空：桌面端的后端地址是**运行期配置**
       # （userData/config.json 的 serverUrl），编译期写死会让同一个包只能连一个环境。
       - name: 构建渲染层
@@ -104,20 +137,12 @@ jobs:
           VITE_API_BASE: ''
         run: pnpm --filter web build
 
-      # 🔴 **不让 electron-builder 自己发**（`--publish never`），产物由下一步用 gh 传。
-      #
-      # 实测（2026-08-27，v0.0.1-rc.1）：`--publish always` 会**建出两个草稿** ——
-      # 它的 GitHub publisher 是每个产物一个上传任务、各自惰性建 release，
-      # 两个任务同时看到「release doesn't exist」就各 POST 了一次，
-      # 而**草稿不按 tag 去重**，于是 GitHub 老老实实建了两个：
-      #   377510322 只有 blockmap
-      #   377510323 有 exe + latest.yml
-      # 而且进程没等 90MB 的 exe 传完就退了，那一版还是「成功」。
-      # 自己传就没有这个竞态，顺带能保证 latest.yml 最后落地（见 apps/desktop/AGENTS.md）。
+      # 🔴 一律 `--publish never`，产物由下面的步骤用 gh 传。
+      # electron-builder 自己传会撞竞态（见 apps/desktop/AGENTS.md 的「在线更新」一节）。
       - name: 出安装包
         run: pnpm --filter @admin/desktop package:ci
 
-      - name: 发到 GitHub Release（草稿）
+      - name: 传到草稿 Release
         if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -126,31 +151,28 @@ jobs:
           DIR="apps/desktop/release/$VER"
           ls -lh "$DIR"
 
-          # 幂等：同一个 tag 重跑不该多出一个草稿
-          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release create "$GITHUB_REF_NAME" --draft \
-              --title "$GITHUB_REF_NAME" \
-              --notes-file apps/desktop/release-notes.md
-          fi
+          # 安装包本体 + blockmap（差量更新用）。三个平台各传各的，互不覆盖
+          # shellcheck disable=SC2086
+          gh release upload "$GITHUB_REF_NAME" ${{ matrix.glob }} --clobber
+          for f in "$DIR"/*.blockmap; do
+            [ -e "$f" ] && gh release upload "$GITHUB_REF_NAME" "$f" --clobber
+          done
 
-          # 🔴 latest.yml **最后**传：它先落地的话，中间那几秒里客户端会拿到
-          # 404 或者半个包 —— 而这两种都不报「更新源没准备好」
-          gh release upload "$GITHUB_REF_NAME" \
-            "$DIR/admin-desktop-$VER-setup.exe" \
-            "$DIR/admin-desktop-$VER-setup.exe.blockmap" --clobber
-          gh release upload "$GITHUB_REF_NAME" "$DIR/latest.yml" --clobber
+          # 🔴 更新清单**最后**传：它先落地的话，中间那几秒里客户端会拿到 404
+          # 或者半个包 —— 而这两种都不报「更新源没准备好」。
+          # 三个平台的清单文件名不同（latest.yml / latest-mac.yml / latest-linux.yml），
+          # 所以互不相踩
+          for f in "$DIR"/latest*.yml; do
+            [ -e "$f" ] && gh release upload "$GITHUB_REF_NAME" "$f" --clobber
+          done
 
-          echo "草稿已就绪：$(gh release view "$GITHUB_REF_NAME" --json url -q .url)"
-
-      - name: 上传安装包（试跑时留个下载入口）
+      - name: 上传产物（试跑时留个下载入口）
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: admin-desktop-${{ steps.ver.outputs.value }}
-          # 只要安装包本体 + blockmap（差量更新用）。写 `**/*.exe` 会把
-          # win-unpacked 里的 admin-desktop.exe / elevate.exe 一起卷进来 ——
-          # 实测 artifact 从 ~90MB 涨到 195MB，而那些文件下载下来没用
+          name: desktop-${{ matrix.os }}-${{ steps.ver.outputs.value }}
           path: |
-            apps/desktop/release/*/*setup.exe
-            apps/desktop/release/*/*setup.exe.blockmap
+            apps/desktop/release/*/*.exe
+            apps/desktop/release/*/*.dmg
+            apps/desktop/release/*/*.AppImage
           if-no-files-found: error

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -26,6 +26,34 @@ CI 的 `release.yml` 里这两步是写死的顺序，本地手打包要自己�
 （`turbo` 的 `@admin/desktop#build` 声明了 `dependsOn: web#build`，所以走
 `pnpm build` 也对；但 `pnpm --filter @admin/desktop package` **不经过** turbo 那条依赖。）
 
+## 三个平台：谁能打、打出来能不能用
+
+| 平台 | 产物 | 谁能打 | 装了能用吗 | 自动更新 |
+|---|---|---|---|---|
+| Windows x64 | `nsis`（`.exe`） | **只能在 Windows 上**（从 mac/linux 交叉打要 Wine，不做） | ✅ SmartScreen 拦一次 | ✅ |
+| macOS arm64 / x64 | `dmg`（给人装）+ `zip`（给更新器） | **只能在 macOS 上**（dmg 要 macOS 工具链） | ⚠️ 未公证 → Gatekeeper 说「已损坏」，要右键打开或 `xattr -dr com.apple.quarantine` | 🔴 **不工作** |
+| Linux x64 | `AppImage` | Linux（也能在 mac 上打，但没验过） | ✅ `chmod +x` 直接跑 | ✅ |
+
+所以 `release.yml` 是**三个 runner 的矩阵**，不是一台机器出三份。仓库是 public，
+GitHub 的 macOS runner 不额外计费。
+
+🔴 **macOS 的自动更新必须签名。** electron-updater 会校验**运行中那个应用**的代码签名，
+拿不到就拒绝安装更新 —— 表现是「检查到新版本、下完了、装不上」。这不是配置能绕过去的，
+要 Apple Developer ID（$99/年）+ notarize。在那之前 mac 版只能手动下 dmg 覆盖安装。
+
+⚠️ **mac 的 `zip` target 不能省。** 更新器读的是 zip 不是 dmg，只出 dmg 的话
+`latest-mac.yml` 里没有可用条目，更新链路直接断。
+
+⚠️ 三个平台的更新清单文件名不同（`latest.yml` / `latest-mac.yml` / `latest-linux.yml`），
+所以三个 job 往同一个 release 传不会互相覆盖。
+
+### 🔴 草稿必须先建好，且只建一次
+
+三个平台的 job 是并行的。让它们各自「没有就建一个」会撞出多个草稿 ——
+GitHub 的草稿**不按 tag 去重**（实测见下面「在线更新」第 4 条）。
+所以 `release.yml` 里有一个单独的 `prepare` job 先把草稿建出来，
+`build` 矩阵只负责往里传文件。
+
 ## 发布的两条路线
 
 | | 用在哪 | 产物去哪 |

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -18,7 +18,11 @@ directories:
   buildResources: build
 
 # 默认名字是 `Admin Desktop Setup 0.0.1.exe` —— 带空格的文件名进 GitHub Release
-# 下载链接会变成一串 `%20`，也不好写进部署脚本。显式压平：
+# 下载链接会变成一串 `%20`，也不好写进部署脚本。显式压平。
+#
+# 🔴 **一个平台 一个模板，而且带 arch 的必须带 `${arch}`。** mac 要出 arm64 和 x64
+# 两份，共用一个不含 `${arch}` 的模板会让后打的那份**覆盖**前一份 ——
+# 产物目录里只剩一个 dmg，而且你分不出它是哪个架构的。
 artifactName: admin-desktop-${version}-setup.${ext}
 
 # 只把主进程/preload 的产物和 package.json 打进 asar。
@@ -42,7 +46,12 @@ extraResources:
     to: native
     filter: ["**/*", "!.gitkeep"]
 
+# ── 三个平台的产物 ──
+# 🔴 **每个平台只能在自己的机器上打**：mac 的 dmg 需要 macOS 的工具链，
+# Windows 的 nsis 从 mac/linux 交叉打要 Wine。所以 release 流水线是三个 runner
+# 的矩阵（`.github/workflows/release.yml`），不是一台机器出三份。
 win:
+  # Windows 只出 x64 一份，沿用顶部那个 `-setup` 命名
   target:
     - target: nsis
       arch: [x64]
@@ -51,16 +60,29 @@ win:
   # signtoolOptions:
   #   certificateFile: ...
 
-# 交付目标是 Windows。下面这两段只为了让开发机（Mac / Linux）能跑
-# `package:dir` 出一个能双击的产物做本地验证 —— 不要拿它们发布。
 mac:
   target:
-    - target: dir
+    # dmg 给人装，zip 给 electron-updater 用（macOS 的自动更新读 zip，不读 dmg）
+    - target: dmg
+      arch: [arm64, x64]
+    - target: zip
+      arch: [arm64, x64]
+  # 两个架构 → 名字里必须有 arch
+  artifactName: admin-desktop-${version}-${arch}.${ext}
   category: public.app-category.business
-  # 自助终端不需要 Mac 版，所以不配签名与公证；真要发 Mac 版得补 notarize
+  # ⚠️ **没有签名，也没有公证。** 代价写在 apps/desktop/release-notes.md 里：
+  # 用户下下来双击会被 Gatekeeper 拦成「已损坏」，要右键打开或者
+  # `xattr -dr com.apple.quarantine`。而且 **macOS 上未签名的包自动更新是不工作的** ——
+  # electron-updater 要校验运行中应用的代码签名。要真发 Mac 版就得买 Developer ID
+  # （$99/年）+ notarize，那是一笔独立的决定，不是打包配置能绕过去的。
+
 linux:
   target:
-    - target: dir
+    # AppImage：不用装、chmod +x 就能跑，且 electron-updater 支持它
+    - target: AppImage
+      arch: [x64]
+  artifactName: admin-desktop-${version}-${arch}.${ext}
+  category: Office
 
 nsis:
   oneClick: false

--- a/apps/desktop/release-notes.md
+++ b/apps/desktop/release-notes.md
@@ -1,8 +1,39 @@
-桌面客户端安装包（Windows x64）。
+> **fastapi-react-admin** 的桌面客户端 —— 把 web 后台装进 Electron 外壳，
+> 提供浏览器给不了的四件事：静默打印、本地硬件、凭据托管、自动更新。
+> 后台本身（页面、权限、多页签）和浏览器版是同一份代码。
 
-- **未签名** —— SmartScreen 会拦一次（「更多信息 → 仍要运行」）。正式交付请在有代码签名证书的机器上打包
-- **per-user 安装**（装进 `%LOCALAPPDATA%\Programs`），不需要管理员权限；自动更新也不会弹 UAC
-- 首次启动要填**后端服务器地址** —— 那是运行期配置，同一个安装包可以连不同环境
-- 自动更新默认读这个仓库的 Release。内网部署可以在客户机的 `config.json` 里填 `updateUrl`，覆盖成自己的静态目录，不必为内网单独打一版
+## 下哪个
 
-> 这个 release 还是**草稿**时，老客户端检查不到它 —— 点了 Publish 才生效。
+| 平台 | 文件 | 说明 |
+|---|---|---|
+| Windows 10/11 x64 | `admin-desktop-<版本>-setup.exe` | NSIS 安装向导，**装到当前用户**（`%LOCALAPPDATA%\Programs`），不需要管理员 |
+| macOS Apple Silicon | `...-arm64.dmg` | M1 及以后 |
+| macOS Intel | `...-x64.dmg`（文件名不带 arm64） | |
+| Linux x64 | `...-x86_64.AppImage` | `chmod +x` 后直接运行，不用装 |
+
+`.blockmap` 与 `latest*.yml` 是**自动更新**用的，人不需要下载。
+
+## 装完第一件事：填后端地址
+
+首次启动会让你填**服务器地址**（如 `https://admin.example.com`）。它是**运行期配置**，
+存在用户目录里 —— 所以同一个安装包可以连不同环境，不用为每个环境各打一版。
+
+## 已知限制（都是刻意的取舍，不是漏做）
+
+- 🔴 **所有平台的包都没有代码签名。**
+  - Windows：SmartScreen 会拦一次 →「更多信息」→「仍要运行」
+  - macOS：Gatekeeper 会说**「已损坏，应移到废纸篓」**。这不是包坏了，是没有公证：
+    右键 →「打开」，或者 `xattr -dr com.apple.quarantine /Applications/Admin\ Desktop.app`
+  - 正式交付请在有证书的机器上打包（Windows 代码签名证书 / Apple Developer ID + notarize）
+- 🔴 **macOS 上的自动更新不工作**（未签名）。electron-updater 要校验运行中应用的代码签名，
+  拿不到就拒绝安装更新。Windows 与 Linux(AppImage) 的自动更新正常
+- **读卡器等本地硬件是桩模式**：厂商的原生助手不在仓库里（那是现场的东西），
+  所以这个包里没有。界面上相关功能会走模拟数据
+- **打印**：Windows 上是真的静默打印；macOS/Linux 上打印链路能跑，但没有在真机标签机上验过
+
+## 更新从哪来
+
+默认读这个仓库的 Release。内网部署（客户出不去公网）可以在客户机的 `config.json` 里
+填 `updateUrl`，指向自己的静态目录 —— **不用为内网单独打一版**。
+
+---

--- a/scripts/ctx-check.mjs
+++ b/scripts/ctx-check.mjs
@@ -89,6 +89,8 @@ const ALLOW = new Map(Object.entries({
   'command.tsx': 'cmdk 封装，零调用方已连依赖链一起删除；文档在讲「不要把它引回来」',
   'version.json': '构建产物（vite 发到 dist 根目录），不进 git',
   'latest.yml': 'electron-builder 的产物（更新清单），不进 git',
+  'latest-mac.yml': '同上，macOS 的更新清单',
+  'latest-linux.yml': '同上，Linux 的更新清单',
   'app-update.yml': '同上，打包时写进安装包的 resources/',
   'userData/config.json': '桌面端运行期在用户目录生成的配置',
   'config.json': '同上',


### PR DESCRIPTION
## 之前为什么只有 Windows

`electron-builder.yml` 里 mac / linux 的 target 是 `dir`，注释写着「只为了让开发机跑 `package:dir` 做本地验证，不要拿它们发布」。而外壳本身是**真跨平台**的 —— 凭据走 `safeStorage`（Windows DPAPI / macOS Keychain），读卡器在非 Windows 自动落桩，平台特化只有 `window-all-closed` 那一行。所以缺的只是产物配置 + 一条能在三种 runner 上跑的流水线。

## 产物

| 平台 | 产物 | 谁能打 | 装了能用吗 | 自动更新 |
|---|---|---|---|---|
| Windows x64 | `nsis` | 只能在 Windows | ✅ SmartScreen 拦一次 | ✅ |
| macOS arm64 / x64 | `dmg` + `zip` | 只能在 macOS | ⚠️ 未公证 → Gatekeeper 说「已损坏」 | 🔴 **不工作** |
| Linux x64 | `AppImage` | Linux | ✅ chmod +x 直接跑 | ✅ |

⚠️ **mac 的 `zip` 不能省**：更新器读 zip 不读 dmg，只出 dmg 的话 `latest-mac.yml` 里没有可用条目，更新链路直接断。

## 两个坑（一个刚踩过，一个提前拦住）

- 🔴 **草稿必须先建好、且只建一次。** 三个平台的 job 并行，让它们各自「没有就建一个」会撞出多个草稿 —— GitHub 的草稿不按 tag 去重（v0.0.1-rc.1 那次已经踩过）。所以拆成 `prepare` + `build` 矩阵
- 🔴 **`artifactName` 分平台，多架构的必须带 `${arch}`。** mac 出 arm64 + x64 两份，共用一个不含 `${arch}` 的模板会让后打的那份**覆盖**前一份 —— 产物目录里只剩一个 dmg，而且分不出是哪个架构

## 本地实测

Linux AppImage 出包成功：

```
• building   target=AppImage arch=x64 file=release/0.0.0/admin-desktop-0.0.0-x86_64.AppImage
• building embedded block map
→ admin-desktop-0.0.0-x86_64.AppImage, latest-linux.yml
```

顺带确认了 `--publish never` 下 **`latest-linux.yml` 照样生成** —— 这是「产物自己传」那条路的前提（清单由 `publish` 配置段驱动，不是由 `--publish` 开关驱动）。

## 发布说明重写

原来只有四行。现在是一份能给人看的：**下哪个文件**（四个平台/架构一张表）· **装完第一件事是填后端地址**（运行期配置，同一个包能连不同环境）· **已知限制** · **更新从哪来**。

已知限制里最要紧的两条，都不是打包配置能绕过去的：

- 所有平台**都没有代码签名**：Windows 是 SmartScreen；macOS 是 Gatekeeper 直接说「已损坏，应移到废纸篓」，要右键打开或 `xattr -dr com.apple.quarantine`
- **macOS 的自动更新不工作**：electron-updater 要校验运行中应用的代码签名，拿不到就拒绝安装更新 —— 表现是「检查到新版本、下完了、装不上」。要 Apple Developer ID（$99/年）+ notarize

分册补了「三个平台：谁能打、打出来能不能用」一节。

## 合完之后

v0.0.1 目前只有 Windows 一个包、说明也是老的四行。它发布几分钟、**0 下载**，我打算删掉重打同一个版本号 —— 这样 v0.0.1 就是完整的三平台版本，而不是留一个半截的首版在那里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)