### PR TITLE
feat(release): 签名做成可插拔 —— 配上 secrets 就签，没配照旧出未签名包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,8 +139,33 @@ jobs:
 
       # 🔴 一律 `--publish never`，产物由下面的步骤用 gh 传。
       # electron-builder 自己传会撞竞态（见 apps/desktop/AGENTS.md 的「在线更新」一节）。
+      # 签名是**可选**的：仓库里配了对应 secrets 就签，没配就出未签名包 ——
+      # 两条路都能跑通，区别只在用户端会不会被 SmartScreen / Gatekeeper 拦。
+      # 怎么申请免费证书、以及 Windows 那条为什么不能「打完再签」，见 apps/desktop/AGENTS.md
       - name: 出安装包
-        run: pnpm --filter @admin/desktop package:ci
+        env:
+          # Windows / macOS 通用：electron-builder 认这两个（.pfx / .p12）
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # macOS 公证（notarize）用
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          EXTRA=""
+          # 只有拿到 Apple 的凭据才开公证 —— 无条件写进 electron-builder.yml 的话，
+          # 没凭据的构建会**直接失败**，而现在这种「没证书也能出包」是刻意保留的
+          if [ -n "${APPLE_TEAM_ID:-}" ] && [ "$RUNNER_OS" = "macOS" ]; then
+            EXTRA="--config.mac.notarize.teamId=$APPLE_TEAM_ID"
+            echo "启用 macOS 公证（teamId=$APPLE_TEAM_ID）"
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            echo "⚠️ 未配 APPLE_* secrets —— 出的是未签名未公证的包，用户要手动过 Gatekeeper"
+          fi
+          # ⚠️ 主进程/preload 要先编 —— `package:ci` 里那一步在这里是手动的，
+          # 漏了它打进包的是上一次的 dist/
+          pnpm --filter @admin/desktop build
+          pnpm --filter @admin/desktop exec electron-builder \
+            --config electron-builder.yml --publish never $EXTRA
 
       - name: 传到草稿 Release
         if: github.event_name == 'push'

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -26,6 +26,42 @@ CI 的 `release.yml` 里这两步是写死的顺序，本地手打包要自己�
 （`turbo` 的 `@admin/desktop#build` 声明了 `dependsOn: web#build`，所以走
 `pnpm build` 也对；但 `pnpm --filter @admin/desktop package` **不经过** turbo 那条依赖。）
 
+## 代码签名：Windows 有免费的路，macOS 没有
+
+现在三个平台出的都是**未签名**包。要接签名的话，先分清「有没有免费证书」这件事
+两个平台的答案完全不同：
+
+| 平台 | 免费方案 | 代价 / 限制 |
+|---|---|---|
+| **Windows** | ✅ **SignPath Foundation** —— 给开源项目免费签（OV 级，私钥在他们的 HSM 里） | 证书签发给 **SignPath Foundation** 而不是本项目，所以 SmartScreen 和安装对话框里显示的发行者是「SignPath Foundation」。要提交申请、代码公开、用被认可的开源许可证 |
+| **Windows（便宜但不免费）** | Certum 的开源开发者证书（约每年几十欧）· Azure Trusted Signing（约 $10/月） | Azure 那条对主体资质有要求（组织要有若干年可核验的存续记录） |
+| **macOS** | 🔴 **没有。** Apple Developer Program $99/年是唯一的路 | 费用减免只给**非营利组织 / 认证教育机构 / 政府实体**，个人和独立开源项目不适用。入会之后**公证本身不额外收费** |
+| **Linux** | 不需要（AppImage 可选 GPG 签名） | —— |
+
+### 🔴 Windows 的签名不能「打完再签」
+
+直觉做法是：打完包 → 把 `.exe` 送去签 → 传上去。**这会把自动更新弄坏** ——
+`latest.yml` 里的 `sha512` 和 `size` 是 electron-builder 按**打包那一刻**的文件算的，
+签名会改变文件内容，于是清单里的哈希对不上，更新器下完校验失败。
+表现是「查到新版本、下完了、装不上」，而错误信息不会提到签名。
+
+正确的接法是让签名发生在**打包过程之内**：electron-builder 的 `win.sign` 钩子指向一个
+自定义脚本，脚本把文件提交给签名服务（SignPath 有现成的 GitHub Action）拿回签好的文件，
+electron-builder 再据此生成 blockmap 与清单。
+
+### 现在的接线方式：有 secrets 就签，没有就出未签名包
+
+`release.yml` 的「出安装包」这一步已经把环境变量直通了，**配上就生效，不用改流水线**：
+
+| secret | 用途 |
+|---|---|
+| `CSC_LINK` / `CSC_KEY_PASSWORD` | 证书文件（.pfx / .p12，base64 或 URL）与密码，Windows 与 macOS 通用 |
+| `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` | macOS 公证 |
+
+⚠️ **公证是按 `APPLE_TEAM_ID` 存在与否动态开的**（`--config.mac.notarize.teamId=...`），
+没写进 `electron-builder.yml`。写死的话，没凭据的构建会**直接失败** ——
+而「没有证书也能出包」是这个模板刻意保留的能力：先能跑，再谈签名。
+
 ## 三个平台：谁能打、打出来能不能用
 
 | 平台 | 产物 | 谁能打 | 装了能用吗 | 自动更新 |

--- a/apps/desktop/release-notes.md
+++ b/apps/desktop/release-notes.md
@@ -24,7 +24,9 @@
   - Windows：SmartScreen 会拦一次 →「更多信息」→「仍要运行」
   - macOS：Gatekeeper 会说**「已损坏，应移到废纸篓」**。这不是包坏了，是没有公证：
     右键 →「打开」，或者 `xattr -dr com.apple.quarantine /Applications/Admin\ Desktop.app`
-  - 正式交付请在有证书的机器上打包（Windows 代码签名证书 / Apple Developer ID + notarize）
+  - Linux：AppImage 不需要签名
+  - 想去掉这些提示：Windows 侧有面向开源项目的免费证书方案（SignPath Foundation），
+    macOS 侧没有免费路，需要 Apple Developer Program（$99/年）
 - 🔴 **macOS 上的自动更新不工作**（未签名）。electron-updater 要校验运行中应用的代码签名，
   拿不到就拒绝安装更新。Windows 与 Linux(AppImage) 的自动更新正常
 - **读卡器等本地硬件是桩模式**：厂商的原生助手不在仓库里（那是现场的东西），


### PR DESCRIPTION
「有没有免费证书」这件事，两个平台答案完全不同：

| 平台 | 免费方案 | 限制 |
|---|---|---|
| **Windows** | ✅ **SignPath Foundation** —— 给开源项目免费签（OV 级，私钥在他们的 HSM） | 证书签发给 SignPath Foundation 而非本项目 → SmartScreen 里显示的发行者是「SignPath Foundation」；要提交申请、代码公开、用被认可的开源许可证 |
| Windows（便宜不免费） | Certum 开源开发者证书 · Azure Trusted Signing（约 $10/月） | Azure 那条对主体资质有要求 |
| **macOS** | 🔴 **没有** | 费用减免只给非营利 / 认证教育机构 / 政府实体，个人和独立开源项目不适用。$99/年入会后**公证不额外收费** |
| Linux | 不需要 | AppImage 可选 GPG |

## 🔴 Windows 的签名不能「打完再签」

直觉做法是打完包 → 送去签 → 传上去。**这会把自动更新弄坏**：`latest.yml` 里的 `sha512` / `size` 是 electron-builder 按打包那一刻的文件算的，签名改变了文件内容 → 清单哈希对不上 → 更新器下完校验失败。表现是「查到新版本、下完了、装不上」，而错误信息不会提到签名。

正确接法是让签名发生在**打包过程之内**（`win.sign` 钩子指向自定义脚本，SignPath 有现成的 GitHub Action），electron-builder 再据签好的文件生成 blockmap 与清单。这条写进分册了，免得将来有人照直觉接。

## 这个 PR 做的事

「出安装包」这一步把签名相关环境变量**直通**了 —— 拿到证书之后只要配 secrets，不用再改流水线：

| secret | 用途 |
|---|---|
| `CSC_LINK` / `CSC_KEY_PASSWORD` | 证书（.pfx / .p12）与密码，Windows 与 macOS 通用 |
| `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` | macOS 公证 |

⚠️ **公证按 `APPLE_TEAM_ID` 存在与否动态开**（`--config.mac.notarize.teamId=…`），**没有**写死进 `electron-builder.yml` —— 写死的话没凭据的构建会直接失败，而「没证书也能出包」是这个模板刻意保留的能力：先能跑，再谈签名。

顺带修一个我自己刚埋的坑：这一步从 `package:ci` 换成手写命令之后，**主进程/preload 的 `build` 不能漏** —— 漏了打进包的是上一次的 `dist/`，而且不报错。本地跑了完整命令验证（Linux AppImage + `latest-linux.yml` 正常产出）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
