### PR TITLE
feat(ui): toast 支持切换弹出位置

### DIFF
--- a/packages/platform/src/pages/dev-sandbox/demos/feedback.tsx
+++ b/packages/platform/src/pages/dev-sandbox/demos/feedback.tsx
@@ -2,11 +2,26 @@ import { Badge } from '@admin/ui/components/badge'
 import { Button } from '@admin/ui/components/button'
 import { Progress, ProgressLabel, ProgressValue } from '@admin/ui/components/progress'
 import { Skeleton } from '@admin/ui/components/skeleton'
-import { toast, type ToastTone } from '@admin/ui/components/toast'
+import {
+  setToastPosition,
+  toast,
+  TOAST_POSITIONS,
+  type ToastPosition,
+  type ToastTone,
+} from '@admin/ui/components/toast'
 
 import { action, b, jsx, lines, n, preview, s, type Demo } from '../kit'
 
 const TONES: ToastTone[] = ['message', 'success', 'info', 'warning', 'error', 'loading']
+
+const POSITION_LABEL: Record<ToastPosition, string> = {
+  'top-start': '左上',
+  'top-center': '顶部居中',
+  'top-end': '右上',
+  'bottom-start': '左下',
+  'bottom-center': '底部居中',
+  'bottom-end': '右下（默认）',
+}
 
 /** 假装一个会成功/失败的请求，给 promise 那一行用 */
 const fakeRequest = (ms: number, ok: boolean) =>
@@ -29,8 +44,25 @@ export const FEEDBACK_DEMOS: Demo[] = [
       description: { kind: 'text', label: '描述', default: '' },
       action: { kind: 'bool', label: '带操作按钮', default: false },
       sticky: { kind: 'bool', label: '不自动消失', default: false, hint: '等价于 timeout: 0' },
+      position: {
+        kind: 'select',
+        label: 'position',
+        options: TOAST_POSITIONS,
+        default: 'bottom-end',
+        hint: '视口是全局单例（app.tsx 只挂一次），切换会立刻影响整个应用当前弹出的位置',
+      },
     },
     rows: [
+      {
+        title: '位置',
+        hint: '六个方位都是 CSS 定位，不是库自带的 —— Base UI 的 Toast 本身不提供 position。点一下就切走全局视口，其余组件示例不受影响。',
+        items: TOAST_POSITIONS.map((position) =>
+          action(POSITION_LABEL[position], () => {
+            setToastPosition(position)
+            toast.message(`已切到「${POSITION_LABEL[position]}」`)
+          })
+        ),
+      },
       {
         title: '类型',
         hint: 'message 是中性通知（无语气色）；loading 转圈且不自动消失，要靠 update 收尾。',
@@ -127,10 +159,14 @@ export const FEEDBACK_DEMOS: Demo[] = [
     ],
     render: (v) => {
       const tone = s(v, 'tone') as ToastTone
+      const position = s(v, 'position') as ToastPosition
       return (
         <div className="flex flex-col items-center gap-3">
           <Button
-            onClick={() =>
+            onClick={() => {
+              // position 是 <Toaster> 级别的配置，不属于这一条 toast() 调用，
+              // 所以点「弹一条」时先切视口，再弹这条
+              setToastPosition(position)
               toast[tone](s(v, 'title'), {
                 description: s(v, 'description') || undefined,
                 ...(b(v, 'sticky') ? { timeout: 0 } : {}),
@@ -138,7 +174,7 @@ export const FEEDBACK_DEMOS: Demo[] = [
                   ? { action: { label: '撤销', onClick: () => toast.success('已撤销') } }
                   : {}),
               })
-            }
+            }}
           >
             弹一条 {tone}
           </Button>
@@ -155,7 +191,12 @@ export const FEEDBACK_DEMOS: Demo[] = [
         b(v, 'action') && "  action: { label: '撤销', onClick: undo },"
       )
       const call = `toast.${s(v, 'tone')}('${s(v, 'title')}'`
-      return opts ? `${call}, {\n${opts}\n})` : `${call})`
+      const toastCall = opts ? `${call}, {\n${opts}\n})` : `${call})`
+      // position 不是这次调用的参数 —— 它挂在全局唯一的 <Toaster>，
+      // 通常在 app.tsx 设一次，或用 setToastPosition() 运行时切换
+      return s(v, 'position') === 'bottom-end'
+        ? toastCall
+        : `setToastPosition('${s(v, 'position')}')  // <Toaster> 是全局单例，这里等价于设置默认方位\n${toastCall}`
     },
   },
 

--- a/packages/platform/src/pages/dev-sandbox/demos/feedback.tsx
+++ b/packages/platform/src/pages/dev-sandbox/demos/feedback.tsx
@@ -17,10 +17,10 @@ const TONES: ToastTone[] = ['message', 'success', 'info', 'warning', 'error', 'l
 const POSITION_LABEL: Record<ToastPosition, string> = {
   'top-start': '左上',
   'top-center': '顶部居中',
-  'top-end': '右上',
+  'top-end': '右上（默认）',
   'bottom-start': '左下',
   'bottom-center': '底部居中',
-  'bottom-end': '右下（默认）',
+  'bottom-end': '右下',
 }
 
 /** 假装一个会成功/失败的请求，给 promise 那一行用 */
@@ -48,7 +48,7 @@ export const FEEDBACK_DEMOS: Demo[] = [
         kind: 'select',
         label: 'position',
         options: TOAST_POSITIONS,
-        default: 'bottom-end',
+        default: 'top-end',
         hint: '视口是全局单例（app.tsx 只挂一次），切换会立刻影响整个应用当前弹出的位置',
       },
     },
@@ -194,7 +194,7 @@ export const FEEDBACK_DEMOS: Demo[] = [
       const toastCall = opts ? `${call}, {\n${opts}\n})` : `${call})`
       // position 不是这次调用的参数 —— 它挂在全局唯一的 <Toaster>，
       // 通常在 app.tsx 设一次，或用 setToastPosition() 运行时切换
-      return s(v, 'position') === 'bottom-end'
+      return s(v, 'position') === 'top-end'
         ? toastCall
         : `setToastPosition('${s(v, 'position')}')  // <Toaster> 是全局单例，这里等价于设置默认方位\n${toastCall}`
     },

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -33,6 +33,64 @@ const manager = ToastPrimitive.createToastManager()
  */
 export type ToastTone = "message" | "info" | "success" | "warning" | "error" | "loading"
 
+/**
+ * 视口出现的方位。用 `start`/`end` 而不是 `left`/`right`（组件约定的逻辑属性习惯）——
+ * RTL 下 `start` 自动变左。`center` 是真正的水平居中，跟方向无关。
+ */
+export type ToastPosition =
+  | "top-start"
+  | "top-center"
+  | "top-end"
+  | "bottom-start"
+  | "bottom-center"
+  | "bottom-end"
+
+export const TOAST_POSITIONS: readonly ToastPosition[] = [
+  "top-start",
+  "top-center",
+  "top-end",
+  "bottom-start",
+  "bottom-center",
+  "bottom-end",
+]
+
+const DEFAULT_POSITION: ToastPosition = "bottom-end"
+
+/**
+ * 位置是运行时可变的模块级状态，不是 `<Toaster>` 的一次性 prop ——
+ * 原因和 `manager` 一样：`<Toaster>` 全局只在 `app.tsx` 挂一次，
+ * 之后任何地方（包括组件沙箱的旋钮）想切换位置，都只能靠 React 外的 setter，
+ * 没有谁能重新往挂载点传 prop。
+ */
+let currentPosition: ToastPosition = DEFAULT_POSITION
+const positionListeners = new Set<() => void>()
+
+export function setToastPosition(position: ToastPosition) {
+  currentPosition = position
+  for (const listen of positionListeners) listen()
+}
+
+function subscribeToPosition(onChange: () => void) {
+  positionListeners.add(onChange)
+  return () => positionListeners.delete(onChange)
+}
+
+function getPositionSnapshot() {
+  return currentPosition
+}
+
+const ToastPositionContext = React.createContext<ToastPosition>(DEFAULT_POSITION)
+
+/** 居中用物理属性（`left-1/2` + `-translate-x-1/2`）—— 居中是唯一和方向无关的取值 */
+const VIEWPORT_POSITION_CLASS: Record<ToastPosition, string> = {
+  "top-start": "top-4 start-4",
+  "top-center": "top-4 left-1/2 -translate-x-1/2",
+  "top-end": "top-4 end-4",
+  "bottom-start": "bottom-4 start-4",
+  "bottom-center": "bottom-4 left-1/2 -translate-x-1/2",
+  "bottom-end": "bottom-4 end-4",
+}
+
 type Options = {
   description?: React.ReactNode
   /** 0 = 不自动消失（错误类默认就是 0，见下） */
@@ -91,10 +149,14 @@ const TONE_CLASS: Record<ToastTone, string> = {
 
 function ToastItem({ toast: item }: { toast: ToastPrimitive.Root.ToastObject }) {
   const { t } = useTranslation()
+  const position = React.useContext(ToastPositionContext)
   // promise() 的 loading 阶段不带 type，按 loading 处理（转圈比信息图标准）
   const tone = (item.type as ToastTone | undefined) ?? "loading"
   const Icon = TONE_ICON[tone] ?? IconInfoCircle
   const spinning = tone === "loading"
+  // 顶部方位从上方落下，底部方位从下方浮起 —— 位置能切换后，
+  // 进场动画方向也要跟着方位走，否则顶部的 toast 会「先往下缩一截再定住」
+  const fromTop = position.startsWith("top")
 
   return (
     <ToastPrimitive.Root
@@ -107,8 +169,10 @@ function ToastItem({ toast: item }: { toast: ToastPrimitive.Root.ToastObject }) 
       className={cn(
         "group/toast relative flex w-full items-start gap-3 rounded-lg border border-border bg-popover p-3.5 pe-9 text-popover-foreground shadow-lg",
         "translate-x-[var(--toast-swipe-movement-x)] translate-y-[var(--toast-swipe-movement-y)] transition-all duration-200",
-        // 进场从下方浮起，离场缩一点淡出；被 limit 顶掉的直接淡出
-        "data-[starting-style]:translate-y-3 data-[starting-style]:opacity-0",
+        // 进场从锚定边浮起，离场缩一点淡出；被 limit 顶掉的直接淡出
+        fromTop
+          ? "data-[starting-style]:-translate-y-3 data-[starting-style]:opacity-0"
+          : "data-[starting-style]:translate-y-3 data-[starting-style]:opacity-0",
         "data-[ending-style]:scale-[0.97] data-[ending-style]:opacity-0",
         "data-[limited]:opacity-0",
         // 拖动过程中不要再叠一层过渡，否则跟手会有橡皮筋感
@@ -144,21 +208,40 @@ function ToastList() {
  * 视口是普通的纵向流式布局（不是绝对定位的叠卡）—— 叠卡要靠
  * `--toast-index` / `--toast-offset-y` 手算位移，多一层出错面，
  * 而这套后台需要的是「看清楚写了什么」，不是炫。
+ *
+ * `position` 不传就跟着运行时状态走（默认 `bottom-end`，可用 `setToastPosition`
+ * 在任何地方切换）；传了就固定成那个值，不再响应 `setToastPosition`。
  */
 export function Toaster({
   children,
   limit = 4,
+  position,
 }: {
   children?: React.ReactNode
   limit?: number
+  position?: ToastPosition
 }) {
+  const livePosition = React.useSyncExternalStore(
+    subscribeToPosition,
+    getPositionSnapshot,
+    getPositionSnapshot
+  )
+  const effectivePosition = position ?? livePosition
+
   return (
     <ToastPrimitive.Provider toastManager={manager} limit={limit}>
       {children}
       <ToastPrimitive.Portal>
-        <ToastPrimitive.Viewport className="fixed end-4 bottom-4 z-100 flex w-[min(calc(100vw-2rem),23rem)] flex-col gap-2.5 outline-none">
-          <ToastList />
-        </ToastPrimitive.Viewport>
+        <ToastPositionContext.Provider value={effectivePosition}>
+          <ToastPrimitive.Viewport
+            className={cn(
+              "fixed z-100 flex w-[min(calc(100vw-2rem),23rem)] flex-col gap-2.5 outline-none",
+              VIEWPORT_POSITION_CLASS[effectivePosition]
+            )}
+          >
+            <ToastList />
+          </ToastPrimitive.Viewport>
+        </ToastPositionContext.Provider>
       </ToastPrimitive.Portal>
     </ToastPrimitive.Provider>
   )

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -54,7 +54,7 @@ export const TOAST_POSITIONS: readonly ToastPosition[] = [
   "bottom-end",
 ]
 
-const DEFAULT_POSITION: ToastPosition = "bottom-end"
+const DEFAULT_POSITION: ToastPosition = "top-end"
 
 /**
  * 位置是运行时可变的模块级状态，不是 `<Toaster>` 的一次性 prop ——
@@ -209,7 +209,7 @@ function ToastList() {
  * `--toast-index` / `--toast-offset-y` 手算位移，多一层出错面，
  * 而这套后台需要的是「看清楚写了什么」，不是炫。
  *
- * `position` 不传就跟着运行时状态走（默认 `bottom-end`，可用 `setToastPosition`
+ * `position` 不传就跟着运行时状态走（默认 `top-end`，可用 `setToastPosition`
  * 在任何地方切换）；传了就固定成那个值，不再响应 `setToastPosition`。
  */
 export function Toaster({


### PR DESCRIPTION
## 背景

`/sandbox/components?c=toast` 里发现 toast 位置固定右下角，改不了。

调查后发现：不是 sonner，是 Base UI 的 `@base-ui/react/toast`——这层组件本身**不提供** `position`（不像 sonner 有 `<Toaster position="..." />` 六个取值内置），之前右下角是 `Viewport` 写死的一行 Tailwind 类（`fixed end-4 bottom-4`）。

## 改动

- `packages/ui/src/components/toast.tsx`
  - 新增 `ToastPosition`（`top/bottom` × `start/center/end`，共 6 个方位）
  - 新增运行时 `setToastPosition()`：`<Toaster>` 全局只在 `app.tsx` 挂一次，任何地方想切位置都只能靠模块级状态（用 `useSyncExternalStore` 订阅），不是靠重新传 prop
  - Viewport 按位置换一张 class 映射；居中用物理属性（`left-1/2 -translate-x-1/2`），因为居中是唯一和方向无关的取值
  - 进场动画方向按 top/bottom 联动（顶部方位从上方落下，底部方位从下方浮起），不联动的话顶部 toast 进场会先往下缩一截再定住
  - `Toaster` 支持传 `position` 显式固定（不传就跟运行时状态走，默认 `bottom-end`，行为不变）

- `packages/platform/src/pages/dev-sandbox/demos/feedback.tsx`
  - Toast 沙箱页加了 `position` 旋钮 + 「位置」示例行（六个方位按钮，点一下立即切换全局视口并弹一条示例通知）

## 验证

- `pnpm typecheck --force`：5/5 通过
- 本地起服务后用 Playwright 登录 → 打开沙箱 → 依次点「左上」「顶部居中」「底部居中」，实测三种方位的 toast 都准确出现在对应位置，居中方位在 1600px 视口下水平居中误差在个位数像素内

## 注意

`setToastPosition()` 改的是全局单例视口，切了之后**整个应用**当前弹出的 toast 都会用新位置，不是只影响沙箱页那一次演示——这是刻意的取舍（`<Toaster>` 全局只挂一次，没有别的办法做到「只在沙箱里生效」），沙箱旋钮的 hint 里也写明了这一点。