### PR TITLE
docs: fork 归属与三数据库现状同步进 CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,10 @@
 **fastapi-react-admin** —— 中后台底座。产品标识集中在 `apps/web/src/lib/brand.ts`
 （改名字、改版本只动那一处）。
 
-后端 fork 自 fastapi-best-architecture 并适配 SQL Server，
+后端 fork 自 [fastapi-best-architecture](https://github.com/fastapi-practices/fastapi_best_architecture)（FBA）
+并新增 SQL Server 支持（现在同时支持 MySQL / PostgreSQL / SQL Server 三种数据库，
+前两种沿用上游、SQL Server 是本仓库加的那一种）；三层结构、插件机制、RBAC 与
+数据权限模型都是 FBA 的设计，归属细节见下面「fork 管理」一节。
 前端基于 React 19 + TanStack Router/Query/Table v9 + shadcn（Base UI 底座）。
 
 架构的承重方式是榫卯：`i18n ← ui ← platform ← web` 严格单向，每层只暴露形状
@@ -372,5 +375,15 @@ stamp 只是把这件事声明出来。
 
 ## fork 管理
 
-上游明确拒绝合并 SQL Server 支持，永久分叉是既定事实。
-基线记在 `apps/api/.upstream-baseline`，只 cherry-pick 上游安全补丁，功能更新不跟。
+后端 fork 自 [fastapi-best-architecture](https://github.com/fastapi-practices/fastapi_best_architecture)
+（FBA）—— 三层结构（`api/v1 → service → crud`）、插件机制、RBAC 与数据权限模型
+都是它的设计，不是本仓库发明的。本仓库在此基础上新增了 SQL Server 支持，现在
+同时支持 MySQL / PostgreSQL / SQL Server 三种数据库；前两种沿用上游写法，
+SQL Server 是本仓库加的那一种。上游明确拒绝合并 SQL Server 支持，所以是永久分叉，
+只 cherry-pick 上游安全补丁，功能更新不跟。
+
+- 分叉基线记在 `apps/api/.upstream-baseline`
+- 上游同为 MIT 协议，原始版权声明保留在 `apps/api/LICENSE`
+- 后端架构文档（三层结构 / 插件机制 / RBAC 的设计意图）看上游那份最全：
+  <https://docs.fba.wu-clan.cc>——本仓库的 `apps/api/AGENTS.md` 只记两件事上游文档没有的：
+  和上游的差异点、以及这里踩过的实测坑

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,6 +1,9 @@
-# apps/api —— FBA fork（SQL Server 适配）
+# apps/api —— FBA fork（新增 SQL Server 支持）
 
-> 三层 `api/v1 → service → crud`。上游拒绝合并 SQL Server 支持，永久分叉。
+> 三层 `api/v1 → service → crud`、插件机制、RBAC/数据权限模型都是 FBA 的设计。
+> 上游拒绝合并 SQL Server 支持，永久分叉——现在同时支持 MySQL / PostgreSQL /
+> SQL Server 三种数据库，SQL Server 是本仓库新增的那一种，其余两种沿用上游。
+> 归属与上游文档链接见根 `CLAUDE.md` 的「fork 管理」。
 >
 > 这份文件是根 `CLAUDE.md` 的**模块分册**，Claude Code 在你读到本目录下的文件时
 > 才把它加载进上下文（惰性加载），所以它可以写得比根文件细。跨模块的硬纪律

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,9 +1,14 @@
 # apps/api
 
-FastAPI 后端。**fork 自 [fastapi-best-architecture](https://github.com/fastapi-practices/fastapi_best_architecture)（FBA）并适配 SQL Server。**
+FastAPI 后端。**fork 自 [fastapi-best-architecture](https://github.com/fastapi-practices/fastapi_best_architecture)（FBA）**——
+三层结构、插件机制、RBAC 与数据权限模型都是它的设计。本仓库在此基础上**新增了
+SQL Server 支持**（现在同时支持 MySQL / PostgreSQL / SQL Server 三种数据库，
+前两种沿用上游、SQL Server 是本仓库加的那一种）。
 
 上游明确拒绝合并 SQL Server 支持，所以这是**永久分叉** —— 只 cherry-pick 上游安全补丁，
-功能更新不跟。基线提交记在 [`.upstream-baseline`](./.upstream-baseline)。
+功能更新不跟。基线提交记在 [`.upstream-baseline`](./.upstream-baseline)。上游同为 MIT，
+原始版权声明保留在 [`LICENSE`](./LICENSE)。后端架构文档看上游那份最全：
+<https://docs.fba.wu-clan.cc>。
 
 > 这个目录下原来有上游的 `README.md` / `README.zh-CN.md` / `CHANGELOG.md` / `CONTRIBUTING.md`。
 > 它们讲的是 FBA 这个项目本身（logo、star 徽章、上游的 release 历史与贡献流程），


### PR DESCRIPTION
## 问题

`CLAUDE.md` 里"分叉 = 适配 SQL Server"的措辞容易读成"只能用 SQL Server"，
而 `backend/core/conf.py: DATABASE_TYPE` 早就是 `mysql/postgresql/sqlserver` 三态。
`README.md` 已经写了完整的归属声明（三层结构/插件机制/RBAC 与数据权限模型是
FBA 的设计、MIT 版权链条、上游文档链接），但没同步进 `CLAUDE.md`——而后者才是
Claude Code 每次开工都会读的那份。

## 改动

- `CLAUDE.md` 开头段 + 「fork 管理」节补上设计归属、MIT 声明、上游文档链接，
  并明确"SQL Server 分叉"指的是相对上游新增了什么，不是排他关系
- `apps/api/AGENTS.md` 标题从"SQL Server 适配"改成"新增 SQL Server 支持"
- `apps/api/README.md` 同步措辞

`pnpm ctx:check` 通过（0 错误）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)