### PR TITLE
fix(rbac): 权限/角色/菜单缓存清理挪到事务提交之后，logout 补清用户快照

### DIFF
--- a/apps/api/backend/app/admin/api/v1/sys/data_rule.py
+++ b/apps/api/backend/app/admin/api/v1/sys/data_rule.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query
 
 from backend.app.admin.schema.data_rule import (
     CreateDataRuleParam,
@@ -113,10 +113,11 @@ async def create_data_rule(
 )
 async def update_data_rule(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='数据规则 ID')],
     obj: UpdateDataRuleParam,
 ) -> ResponseModel:
-    count = await data_rule_service.update(db=db, pk=pk, obj=obj)
+    count = await data_rule_service.update(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()
@@ -130,8 +131,10 @@ async def update_data_rule(
         DependsRBAC,
     ],
 )
-async def delete_data_rules(db: CurrentSessionTransaction, obj: DeleteDataRuleParam) -> ResponseModel:
-    count = await data_rule_service.delete(db=db, obj=obj)
+async def delete_data_rules(
+    db: CurrentSessionTransaction, background_tasks: BackgroundTasks, obj: DeleteDataRuleParam
+) -> ResponseModel:
+    count = await data_rule_service.delete(db=db, background_tasks=background_tasks, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()

--- a/apps/api/backend/app/admin/api/v1/sys/data_scope.py
+++ b/apps/api/backend/app/admin/api/v1/sys/data_scope.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query
 
 from backend.app.admin.schema.data_scope import (
     CreateDataScopeParam,
@@ -85,10 +85,11 @@ async def create_data_scope(db: CurrentSessionTransaction, obj: CreateDataScopeP
 )
 async def update_data_scope(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='数据范围 ID')],
     obj: UpdateDataScopeParam,
 ) -> ResponseModel:
-    count = await data_scope_service.update(db=db, pk=pk, obj=obj)
+    count = await data_scope_service.update(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()
@@ -104,11 +105,12 @@ async def update_data_scope(
 )
 async def update_data_scope_rules(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='数据范围 ID')],
     rule_ids: UpdateDataScopeRuleParam,
 ) -> ResponseModel:
     # 返回值是「写了几条关联」，不是成败 —— 把规则清空（rules=[]）时它就是 0，那是合法保存
-    await data_scope_service.update_data_scope_rule(db=db, pk=pk, rule_ids=rule_ids)
+    await data_scope_service.update_data_scope_rule(db=db, background_tasks=background_tasks, pk=pk, rule_ids=rule_ids)
     return response_base.success()
 
 
@@ -120,8 +122,10 @@ async def update_data_scope_rules(
         DependsRBAC,
     ],
 )
-async def delete_data_scopes(db: CurrentSessionTransaction, obj: DeleteDataScopeParam) -> ResponseModel:
-    count = await data_scope_service.delete(db=db, obj=obj)
+async def delete_data_scopes(
+    db: CurrentSessionTransaction, background_tasks: BackgroundTasks, obj: DeleteDataScopeParam
+) -> ResponseModel:
+    count = await data_scope_service.delete(db=db, background_tasks=background_tasks, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()

--- a/apps/api/backend/app/admin/api/v1/sys/menu.py
+++ b/apps/api/backend/app/admin/api/v1/sys/menu.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Path, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query, Request
 
 from backend.app.admin.schema.menu import CreateMenuParam, GetMenuDetail, GetMenuTree, UpdateMenuParam
 from backend.app.admin.service.menu_service import menu_service
@@ -73,9 +73,12 @@ async def create_menu(db: CurrentSessionTransaction, obj: CreateMenuParam) -> Re
     ],
 )
 async def update_menu(
-    db: CurrentSessionTransaction, pk: Annotated[int, Path(description='菜单 ID')], obj: UpdateMenuParam
+    db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
+    pk: Annotated[int, Path(description='菜单 ID')],
+    obj: UpdateMenuParam,
 ) -> ResponseModel:
-    count = await menu_service.update(db=db, pk=pk, obj=obj)
+    count = await menu_service.update(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()
@@ -89,8 +92,10 @@ async def update_menu(
         DependsRBAC,
     ],
 )
-async def delete_menu(db: CurrentSessionTransaction, pk: Annotated[int, Path(description='菜单 ID')]) -> ResponseModel:
-    count = await menu_service.delete(db=db, pk=pk)
+async def delete_menu(
+    db: CurrentSessionTransaction, background_tasks: BackgroundTasks, pk: Annotated[int, Path(description='菜单 ID')]
+) -> ResponseModel:
+    count = await menu_service.delete(db=db, background_tasks=background_tasks, pk=pk)
     if count > 0:
         return response_base.success()
     return response_base.fail()

--- a/apps/api/backend/app/admin/api/v1/sys/role.py
+++ b/apps/api/backend/app/admin/api/v1/sys/role.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Query
 
 from backend.app.admin.schema.menu import GetMenuTree
 from backend.app.admin.schema.role import (
@@ -95,9 +95,12 @@ async def create_role(db: CurrentSessionTransaction, obj: CreateRoleParam) -> Re
     ],
 )
 async def update_role(
-    db: CurrentSessionTransaction, pk: Annotated[int, Path(description='角色 ID')], obj: UpdateRoleParam
+    db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
+    pk: Annotated[int, Path(description='角色 ID')],
+    obj: UpdateRoleParam,
 ) -> ResponseModel:
-    count = await role_service.update(db=db, pk=pk, obj=obj)
+    count = await role_service.update(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()
@@ -113,12 +116,13 @@ async def update_role(
 )
 async def update_role_menus(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='角色 ID')],
     menu_ids: UpdateRoleMenuParam,
 ) -> ResponseModel:
     # 返回值是「写入了几条关联」，不是成功与否 —— 把授权清空（menus=[]）时它就是 0，
     # 那是一次合法保存。角色不存在的情况 service 里已经抛 NotFoundError 了。
-    await role_service.update_role_menu(db=db, pk=pk, menu_ids=menu_ids)
+    await role_service.update_role_menu(db=db, background_tasks=background_tasks, pk=pk, menu_ids=menu_ids)
     return response_base.success()
 
 
@@ -132,12 +136,13 @@ async def update_role_menus(
 )
 async def add_role_users(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='角色 ID')],
     obj: UpdateRoleUserParam,
 ) -> ResponseModel:
     # 只往 user_role 里加这一条关联，用户已有的其它角色不动 ——
     # 走 PUT /users/{pk} 改 roles 会连带覆盖整个用户对象
-    await role_service.add_users(db=db, pk=pk, obj=obj)
+    await role_service.add_users(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     return response_base.success()
 
 
@@ -151,10 +156,11 @@ async def add_role_users(
 )
 async def remove_role_users(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='角色 ID')],
     obj: UpdateRoleUserParam,
 ) -> ResponseModel:
-    await role_service.remove_users(db=db, pk=pk, obj=obj)
+    await role_service.remove_users(db=db, background_tasks=background_tasks, pk=pk, obj=obj)
     return response_base.success()
 
 
@@ -168,11 +174,12 @@ async def remove_role_users(
 )
 async def update_role_scopes(
     db: CurrentSessionTransaction,
+    background_tasks: BackgroundTasks,
     pk: Annotated[int, Path(description='角色 ID')],
     scope_ids: UpdateRoleScopeParam,
 ) -> ResponseModel:
     # 同上：scopes=[] 是「不绑任何数据范围」，不是失败
-    await role_service.update_role_scope(db=db, pk=pk, scope_ids=scope_ids)
+    await role_service.update_role_scope(db=db, background_tasks=background_tasks, pk=pk, scope_ids=scope_ids)
     return response_base.success()
 
 
@@ -184,8 +191,10 @@ async def update_role_scopes(
         DependsRBAC,
     ],
 )
-async def delete_roles(db: CurrentSessionTransaction, obj: DeleteRoleParam) -> ResponseModel:
-    count = await role_service.delete(db=db, obj=obj)
+async def delete_roles(
+    db: CurrentSessionTransaction, background_tasks: BackgroundTasks, obj: DeleteRoleParam
+) -> ResponseModel:
+    count = await role_service.delete(db=db, background_tasks=background_tasks, obj=obj)
     if count > 0:
         return response_base.success()
     return response_base.fail()

--- a/apps/api/backend/app/admin/service/auth_service.py
+++ b/apps/api/backend/app/admin/service/auth_service.py
@@ -318,6 +318,11 @@ class AuthService:
         await redis_client.delete(f'{settings.TOKEN_EXTRA_INFO_REDIS_PREFIX}:{user_id}:{session_uuid}')
         if refresh_token:
             await redis_client.delete(f'{settings.TOKEN_REFRESH_REDIS_PREFIX}:{user_id}:{session_uuid}')
+        # 🔴 见 issue #34：这份用户快照（menu_service.get_sidebar 用它筛菜单）原来
+        # 只被 user_cache_manager.clear_* 显式作废，logout 从不碰它——一旦它被卡在
+        # 旧值上（比如另一个管理员改权限的请求撞上了竞态），重新登录并不能重建它，
+        # 用户能想到的所有恢复动作里，这是唯一真正有效的一个，必须补上。
+        await redis_client.delete(f'{settings.JWT_USER_REDIS_PREFIX}:{user_id}')
 
 
 auth_service: AuthService = AuthService()

--- a/apps/api/backend/app/admin/service/data_rule_service.py
+++ b/apps/api/backend/app/admin/service/data_rule_service.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from sqlalchemy import Table
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTasks
 
 from backend.app.admin.crud.crud_data_rule import data_rule_dao
 from backend.app.admin.model import DataRule
@@ -198,11 +199,14 @@ class DataRuleService:
         return await data_rule_dao.create(db, obj)
 
     @classmethod
-    async def update(cls, *, db: AsyncSession, pk: int, obj: UpdateDataRuleParam) -> int:
+    async def update(
+        cls, *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateDataRuleParam
+    ) -> int:
         """
         更新数据规则
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 规则 ID
         :param obj: 规则更新参数
         :return:
@@ -214,20 +218,21 @@ class DataRuleService:
         if data_rule.name != obj.name and await data_rule_dao.get_by_name(db, obj.name):
             raise errors.ConflictError(msg=t('error.data_rule.already_exists'))
         count = await data_rule_dao.update(db, pk, obj)
-        await user_cache_manager.clear_by_data_rule_id(db, [pk])
+        await user_cache_manager.clear_by_data_rule_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def delete(*, db: AsyncSession, obj: DeleteDataRuleParam) -> int:
+    async def delete(*, db: AsyncSession, background_tasks: BackgroundTasks, obj: DeleteDataRuleParam) -> int:
         """
         批量删除数据规则
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param obj: 规则 ID 列表
         :return:
         """
         count = await data_rule_dao.delete(db, obj.pks)
-        await user_cache_manager.clear_by_data_rule_id(db, obj.pks)
+        await user_cache_manager.clear_by_data_rule_id(db, background_tasks, obj.pks)
         return count
 
 

--- a/apps/api/backend/app/admin/service/data_scope_service.py
+++ b/apps/api/backend/app/admin/service/data_scope_service.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTasks
 
 from backend.app.admin.crud.crud_data_rule import data_rule_dao
 from backend.app.admin.crud.crud_data_scope import data_scope_dao
@@ -91,11 +92,12 @@ class DataScopeService:
         await data_scope_dao.create(db, obj)
 
     @staticmethod
-    async def update(*, db: AsyncSession, pk: int, obj: UpdateDataScopeParam) -> int:
+    async def update(*, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateDataScopeParam) -> int:
         """
         更新数据范围
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 范围 ID
         :param obj: 数据范围更新参数
         :return:
@@ -106,15 +108,18 @@ class DataScopeService:
         if data_scope.name != obj.name and await data_scope_dao.get_by_name(db, obj.name):
             raise errors.ConflictError(msg=t('error.data_scope.already_exists'))
         count = await data_scope_dao.update(db, pk, obj)
-        await user_cache_manager.clear_by_data_scope_id(db, [pk])
+        await user_cache_manager.clear_by_data_scope_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def update_data_scope_rule(*, db: AsyncSession, pk: int, rule_ids: UpdateDataScopeRuleParam) -> int:
+    async def update_data_scope_rule(
+        *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, rule_ids: UpdateDataScopeRuleParam
+    ) -> int:
         """
         更新数据范围规则
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 范围 ID
         :param rule_ids: 规则 ID 列表
         :return:
@@ -127,20 +132,21 @@ class DataScopeService:
             if {rule.id for rule in rules} != set(rule_ids.rules):
                 raise errors.NotFoundError(msg=t('error.data_rule.not_found'))
         count = await data_scope_dao.update_rules(db, pk, rule_ids)
-        await user_cache_manager.clear_by_data_scope_id(db, [pk])
+        await user_cache_manager.clear_by_data_scope_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def delete(*, db: AsyncSession, obj: DeleteDataScopeParam) -> int:
+    async def delete(*, db: AsyncSession, background_tasks: BackgroundTasks, obj: DeleteDataScopeParam) -> int:
         """
         批量删除数据范围
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param obj: 范围 ID 列表
         :return:
         """
         count = await data_scope_dao.delete(db, obj.pks)
-        await user_cache_manager.clear_by_data_scope_id(db, obj.pks)
+        await user_cache_manager.clear_by_data_scope_id(db, background_tasks, obj.pks)
         return count
 
 

--- a/apps/api/backend/app/admin/service/menu_service.py
+++ b/apps/api/backend/app/admin/service/menu_service.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTasks
 
 from backend.app.admin.crud.crud_menu import menu_dao
 from backend.app.admin.model import Menu
@@ -91,11 +92,12 @@ class MenuService:
         await menu_dao.create(db, obj)
 
     @staticmethod
-    async def update(*, db: AsyncSession, pk: int, obj: UpdateMenuParam) -> int:
+    async def update(*, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateMenuParam) -> int:
         """
         更新菜单
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 菜单 ID
         :param obj: 菜单更新参数
         :return:
@@ -113,15 +115,16 @@ class MenuService:
         if obj.parent_id == menu.id:
             raise errors.ForbiddenError(msg=t('error.dept.cannot_be_own_parent'))
         count = await menu_dao.update(db, pk, obj)
-        await user_cache_manager.clear_by_menu_id(db, [pk])
+        await user_cache_manager.clear_by_menu_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def delete(*, db: AsyncSession, pk: int) -> int:
+    async def delete(*, db: AsyncSession, background_tasks: BackgroundTasks, pk: int) -> int:
         """
         删除菜单
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 菜单 ID
         :return:
         """
@@ -131,7 +134,7 @@ class MenuService:
             raise errors.ConflictError(msg=t('error.menu.has_children'))
         count = await menu_dao.delete(db, pk)
         if count:
-            await user_cache_manager.clear_by_menu_id(db, [pk])
+            await user_cache_manager.clear_by_menu_id(db, background_tasks, [pk])
         return count
 
 

--- a/apps/api/backend/app/admin/service/role_service.py
+++ b/apps/api/backend/app/admin/service/role_service.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTasks
 
 from backend.app.admin.crud.crud_data_scope import data_scope_dao
 from backend.app.admin.crud.crud_menu import menu_dao
@@ -53,9 +54,7 @@ class RoleService:
         return roles
 
     @staticmethod
-    async def get_list(
-        *, db: AsyncSession, name: str | None, code: str | None, status: int | None
-    ) -> dict[str, Any]:
+    async def get_list(*, db: AsyncSession, name: str | None, code: str | None, status: int | None) -> dict[str, Any]:
         """
         获取角色列表
 
@@ -118,11 +117,12 @@ class RoleService:
         await role_dao.create(db, obj)
 
     @staticmethod
-    async def update(*, db: AsyncSession, pk: int, obj: UpdateRoleParam) -> int:
+    async def update(*, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateRoleParam) -> int:
         """
         更新角色
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 角色 ID
         :param obj: 角色更新参数
         :return:
@@ -134,15 +134,18 @@ class RoleService:
         if role.name != obj.name and await role_dao.get_by_name(db, obj.name):
             raise errors.ConflictError(msg=t('error.role.already_exists'))
         count = await role_dao.update(db, pk, obj)
-        await user_cache_manager.clear_by_role_id(db, [pk])
+        await user_cache_manager.clear_by_role_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def update_role_menu(*, db: AsyncSession, pk: int, menu_ids: UpdateRoleMenuParam) -> int:
+    async def update_role_menu(
+        *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, menu_ids: UpdateRoleMenuParam
+    ) -> int:
         """
         更新角色菜单
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 角色 ID
         :param menu_ids: 菜单 ID 列表
         :return:
@@ -156,15 +159,18 @@ class RoleService:
             if {menu.id for menu in menus} != set(menu_ids.menus):
                 raise errors.NotFoundError(msg=t('error.menu.not_found'))
         count = await role_dao.update_menus(db, pk, menu_ids)
-        await user_cache_manager.clear_by_role_id(db, [pk])
+        await user_cache_manager.clear_by_role_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def add_users(*, db: AsyncSession, pk: int, obj: UpdateRoleUserParam) -> int:
+    async def add_users(
+        *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateRoleUserParam
+    ) -> int:
         """
         给角色添加用户
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 角色 ID
         :param obj: 用户 ID 列表
         :return:
@@ -181,15 +187,18 @@ class RoleService:
 
         count = await role_dao.add_users(db, pk, user_ids)
         # 权限码和侧边栏都缓存在 Redis 里，不清的话新角色要等 token 过期才生效
-        await user_cache_manager.clear(user_ids)
+        user_cache_manager.clear(background_tasks, user_ids)
         return count
 
     @staticmethod
-    async def remove_users(*, db: AsyncSession, pk: int, obj: UpdateRoleUserParam) -> int:
+    async def remove_users(
+        *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, obj: UpdateRoleUserParam
+    ) -> int:
         """
         把用户移出角色
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 角色 ID
         :param obj: 用户 ID 列表
         :return:
@@ -200,15 +209,18 @@ class RoleService:
 
         user_ids = list(dict.fromkeys(obj.users))
         count = await role_dao.remove_users(db, pk, user_ids)
-        await user_cache_manager.clear(user_ids)
+        user_cache_manager.clear(background_tasks, user_ids)
         return count
 
     @staticmethod
-    async def update_role_scope(*, db: AsyncSession, pk: int, scope_ids: UpdateRoleScopeParam) -> int:
+    async def update_role_scope(
+        *, db: AsyncSession, background_tasks: BackgroundTasks, pk: int, scope_ids: UpdateRoleScopeParam
+    ) -> int:
         """
         更新角色数据范围
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param pk: 角色 ID
         :param scope_ids: 权限规则 ID 列表
         :return:
@@ -222,21 +234,22 @@ class RoleService:
             if {scope.id for scope in scopes} != set(scope_ids.scopes):
                 raise errors.NotFoundError(msg=t('error.data_scope.not_found'))
         count = await role_dao.update_scopes(db, pk, scope_ids)
-        await user_cache_manager.clear_by_role_id(db, [pk])
+        await user_cache_manager.clear_by_role_id(db, background_tasks, [pk])
         return count
 
     @staticmethod
-    async def delete(*, db: AsyncSession, obj: DeleteRoleParam) -> int:
+    async def delete(*, db: AsyncSession, background_tasks: BackgroundTasks, obj: DeleteRoleParam) -> int:
         """
         批量删除角色
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param obj: 角色 ID 列表
         :return:
         """
 
         count = await role_dao.delete(db, obj.pks)
-        await user_cache_manager.clear_by_role_id(db, obj.pks)
+        await user_cache_manager.clear_by_role_id(db, background_tasks, obj.pks)
         return count
 
 

--- a/apps/api/backend/app/admin/tests/security/test_user_cache_invalidation.py
+++ b/apps/api/backend/app/admin/tests/security/test_user_cache_invalidation.py
@@ -1,0 +1,171 @@
+"""issue #34：用户权限快照（`fba:user:{id}`）的清理时机 / 覆盖面。
+
+真相来源不是数据库，是一份 TTL = `TOKEN_EXPIRE_SECONDS`（默认 1 天）的 Redis 快照
+（`JWT_USER_REDIS_PREFIX`）——`menu_service.get_sidebar()` 筛菜单用的 `menu_ids`
+来自这份快照，不是每次都重新算。这批用例钉住两件事：
+
+1. `UserCacheManager.clear()` 不能在事务提交前直接删 Redis：所有 `clear_*` 都是从
+   `CurrentSessionTransaction` 端点内调用的，而那类端点的 commit 发生在 handler
+   函数体返回之后（`get_db_transaction` 的 `async with async_db_session.begin()`
+   在依赖退出时才提交）。真正的删除必须registered 为 `BackgroundTasks`——它保证
+   在依赖退出栈（含 commit）关闭之后、响应发出之前才执行，天生晚于提交。
+2. `logout` 必须把这份快照一起清掉，否则一旦被问题 1 描述的竞态卡在旧值上，
+   重新登录（用户唯一想得到的自救动作）并不能恢复它。
+"""
+
+import asyncio
+import uuid
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from starlette.background import BackgroundTasks
+from starlette.testclient import TestClient
+
+from backend.app.admin.utils import cache as cache_module
+from backend.app.admin.utils.cache import user_cache_manager
+from backend.common.security.jwt import jwt_decode
+from backend.core.conf import settings
+from backend.database.redis import RedisCli
+
+
+def _redis_exists(key: str) -> bool:
+    """开一个独立连接查 key 存在与否
+
+    ⚠️ 不能用模块级的全局 `redis_client`——它绑在 `TestClient` 的事件循环上，
+    从这里新起的 `asyncio.run()` 循环里用会 "attached to a different loop"
+    （同 `test_auth.py: _clear_login_counters` 踩过的坑）。
+    """
+
+    async def _check() -> bool:
+        client = RedisCli()
+        try:
+            return bool(await client.exists(key))
+        finally:
+            await client.aclose()
+
+    return asyncio.run(_check())
+
+
+def test_clear_registers_redis_delete_as_background_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`clear()` 必须把真正的删除挂成 background task，不能立刻执行
+
+    用 mock 而不是真实 Redis 连接，是为了避开上面那个"跨事件循环"的坑：
+    `AsyncMock` 不绑定任何循环，可以放心在这里新起的 `asyncio.run()` 里驱动。
+    """
+    mock_delete = AsyncMock()
+    monkeypatch.setattr(cache_module.redis_client, 'delete', mock_delete)
+
+    background_tasks = BackgroundTasks()
+    user_cache_manager.clear(background_tasks, [123456, 654321])
+
+    # 此刻——相当于"事务还没提交"的那一刻——真正的 Redis 删除还不能发生
+    mock_delete.assert_not_called()
+
+    # 模拟 FastAPI 在响应发出前执行 background tasks（commit 已经在此之前完成）
+    asyncio.run(background_tasks())
+
+    mock_delete.assert_called_once_with(
+        f'{settings.JWT_USER_REDIS_PREFIX}:123456',
+        f'{settings.JWT_USER_REDIS_PREFIX}:654321',
+    )
+
+
+def test_update_role_menus_clears_admin_snapshot_by_the_time_response_returns(
+    client: TestClient, token_headers: dict[str, str]
+) -> None:
+    """端到端回归：改角色菜单，admin 自己的 `fba:user:{id}` 必须已经被清
+
+    走真实的 `PUT /sys/roles/{pk}/menus`，而不是直接调 service 函数——
+    这条测试同时验证了"background task 真的被 FastAPI 执行了"这件事本身，
+    单测 `UserCacheManager` 证明不了这个（mock 不会漏接，但接口层可能忘了
+    把 `background_tasks` 参数一路传下去）。
+    """
+    access_token = token_headers['Authorization'].split(' ', 1)[1]
+    admin_user_id = jwt_decode(access_token).user_id
+
+    role_code = f'ZCACHETEST{uuid.uuid4().hex[:10].upper()}'
+    create_resp = client.post(
+        '/sys/roles',
+        json={'name': role_code, 'code': role_code, 'status': 1, 'remark': None},
+        headers=token_headers,
+    )
+    assert create_resp.status_code == 200, create_resp.text
+
+    list_resp = client.get('/sys/roles', params={'code': role_code}, headers=token_headers)
+    assert list_resp.status_code == 200, list_resp.text
+    items = list_resp.json()['data']['items']
+    assert items, f'刚创建的角色 {role_code} 应该能被 code 过滤查到'
+    role_pk = items[0]['id']
+
+    try:
+        add_users_resp = client.post(
+            f'/sys/roles/{role_pk}/users',
+            json={'users': [admin_user_id]},
+            headers=token_headers,
+        )
+        assert add_users_resp.status_code == 200, add_users_resp.text
+
+        # ⚠️ `add_users` 自己也会清一次 admin 的缓存（刚把 admin 加进这个角色，
+        # 它自己的权限就变了）——所以这里的快照这时候已经是空的，不能拿来当
+        # "写入过"的证据。用一次无关的认证请求重新把它填回去，才能确认接下来
+        # `update_role_menus` 造成的删除是它自己的效果，不是延续上一步。
+        snapshot_key = f'{settings.JWT_USER_REDIS_PREFIX}:{admin_user_id}'
+        warm_resp = client.get('/sys/menus/sidebar', headers=token_headers)
+        assert warm_resp.status_code == 200, warm_resp.text
+        assert _redis_exists(snapshot_key), '打完一个认证接口之后，admin 的用户快照应该已经被写进 Redis'
+
+        update_resp = client.put(
+            f'/sys/roles/{role_pk}/menus',
+            json={'menus': []},
+            headers=token_headers,
+        )
+        assert update_resp.status_code == 200, update_resp.text
+
+        # `TestClient` 会跑完包括 background tasks 在内的整条 ASGI 响应流程
+        # 才把 response 对象交回来，所以这里能看到的必须是"已经清掉"。
+        assert not _redis_exists(snapshot_key), (
+            '响应已经返回，说明 commit + background task 都已经跑完，'
+            'admin 的用户快照这时候应该已经被清掉，不是等到下次别的操作才清'
+        )
+    finally:
+        client.request(
+            'DELETE',
+            f'/sys/roles/{role_pk}/users',
+            json={'users': [admin_user_id]},
+            headers=token_headers,
+        )
+        client.request('DELETE', '/sys/roles', json={'pks': [role_pk]}, headers=token_headers)
+
+
+def test_logout_clears_user_snapshot(client: TestClient) -> None:
+    """logout 必须清掉 `fba:user:{id}`，否则问题 1 一旦发生就没有自救路径
+
+    ⚠️ 故意不用共享的 `token_headers`（module 级 fixture）——那个 token 还要给
+    同模块的其它用例用，这里 logout 会让它失效，所以自己单独登录一次。
+    """
+    login_resp = client.post(
+        '/auth/login/swagger',
+        params={'username': 'admin', 'password': '123456'},
+    )
+    login_resp.raise_for_status()
+    body = login_resp.json()
+    access_token = body['access_token']
+    headers = {'Authorization': f'{body["token_type"]} {access_token}'}
+    user_id = jwt_decode(access_token).user_id
+    snapshot_key = f'{settings.JWT_USER_REDIS_PREFIX}:{user_id}'
+
+    # 随便打一个带认证的接口，确保快照被写进 Redis（不依赖它是否已经因为
+    # 别的用例而存在）
+    me_resp = client.get('/sys/menus/sidebar', headers=headers)
+    assert me_resp.status_code == 200, me_resp.text
+    assert _redis_exists(snapshot_key)
+
+    logout_resp = client.post('/auth/logout', headers=headers)
+    assert logout_resp.status_code == 200
+
+    assert not _redis_exists(snapshot_key), (
+        'logout 之后 fba:user:{id} 必须被清掉——否则一旦这份快照被卡在旧值上，'
+        '重新登录（用户唯一想得到的自救动作）没有任何效果'
+    )

--- a/apps/api/backend/app/admin/utils/cache.py
+++ b/apps/api/backend/app/admin/utils/cache.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTasks
 
 from backend.app.admin.model import data_scope_rule, role_data_scope, role_menu, user_role
 from backend.core.conf import settings
@@ -9,24 +10,57 @@ from backend.database.redis import redis_client
 
 
 class UserCacheManager:
-    """用户缓存管理"""
+    """用户缓存管理
+
+    🔴 所有 `clear_*` 都要求传入 `background_tasks`，且真正的 Redis 删除
+    只登记为后台任务，**不在这里直接 await**。
+
+    原因（issue #34）：这些方法都是从 `CurrentSessionTransaction` 端点内调用的，
+    而那类端点的事务提交发生在 handler 函数体返回之后（`get_db_transaction` 的
+    `async with async_db_session.begin()` 在依赖退出时才 commit）。如果这里直接
+    `await redis_client.delete(...)`，删除会发生在**提交之前**——命中这个窗口的
+    并发请求用另一个会话查库读到的还是旧数据，会把旧快照连同完整 TTL 重新写回
+    Redis，之后即便我们的事务提交了，也没有人再清一次，缓存会锁死在旧值上
+    直到 TTL 到期（默认 `TOKEN_EXPIRE_SECONDS` = 1 天）。
+
+    FastAPI 的 `BackgroundTasks` 保证在响应对象送回 ASGI 服务器**之前**才执行——
+    而依赖的退出栈（含事务提交）在响应对象组装完成之后、发送之前就已经关闭，
+    所以背景任务里做的事必然发生在 commit 之后。这比"两侧都清一次"更彻底：
+    不需要额外补一次提交后的清理，天生就晚于提交。
+    """
 
     @staticmethod
-    async def clear(user_ids: Sequence[int]) -> None:
+    def clear(background_tasks: BackgroundTasks, user_ids: Sequence[int]) -> None:
         """
-        清理用户缓存
+        登记「提交后」清理用户缓存
 
+        :param background_tasks: FastAPI 后台任务（由端点注入，逐层传下来）
         :param user_ids: 用户 ID 列表
         :return:
         """
         if user_ids:
-            await redis_client.delete(*[f'{settings.JWT_USER_REDIS_PREFIX}:{user_id}' for user_id in user_ids])
+            keys = [f'{settings.JWT_USER_REDIS_PREFIX}:{user_id}' for user_id in user_ids]
+            # 🔴 不能直接 `background_tasks.add_task(redis_client.delete, *keys)`。
+            # redis-py 的命令方法是靠元类/注册表动态生成的，`asyncio.iscoroutinefunction`
+            # 认不出它是协程函数（`inspect.iscoroutinefunction(redis_client.delete)`
+            # 实测为 False）。Starlette 的 `BackgroundTask` 靠这个检测判断要不要
+            # `await`——检测失败就当成同步函数扔进线程池执行，而"执行"一个 async
+            # 函数只是**创建**了一个协程对象、没有人 await 它，Redis 命令**根本不会
+            # 发出去**，且只有一条 "coroutine was never awaited" 的警告，没有任何
+            # 报错或异常。包一层显式的 `async def` 就没有这个问题（有实测：加了这层
+            # 之后 `is_async_callable` 才返回 True，端到端测试里 key 才真的被删）。
 
-    async def clear_by_role_id(self, db: AsyncSession, role_ids: list[int]) -> None:
+            async def _delete() -> None:
+                await redis_client.delete(*keys)
+
+            background_tasks.add_task(_delete)
+
+    async def clear_by_role_id(self, db: AsyncSession, background_tasks: BackgroundTasks, role_ids: list[int]) -> None:
         """
         通过角色 ID 清理用户缓存
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param role_ids: 角色 ID 列表
         :return:
         """
@@ -34,13 +68,14 @@ class UserCacheManager:
         result = await db.execute(stmt)
         user_ids = result.scalars().all()
 
-        await self.clear(user_ids)
+        self.clear(background_tasks, user_ids)
 
-    async def clear_by_menu_id(self, db: AsyncSession, menu_ids: list[int]) -> None:
+    async def clear_by_menu_id(self, db: AsyncSession, background_tasks: BackgroundTasks, menu_ids: list[int]) -> None:
         """
         通过菜单 ID 清理用户缓存
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param menu_ids: 菜单 ID 列表
         :return:
         """
@@ -53,13 +88,16 @@ class UserCacheManager:
         result = await db.execute(stmt)
         user_ids = result.scalars().all()
 
-        await self.clear(user_ids)
+        self.clear(background_tasks, user_ids)
 
-    async def clear_by_data_scope_id(self, db: AsyncSession, scope_ids: list[int]) -> None:
+    async def clear_by_data_scope_id(
+        self, db: AsyncSession, background_tasks: BackgroundTasks, scope_ids: list[int]
+    ) -> None:
         """
         通过数据范围 ID 清理用户缓存
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param scope_ids: 数据范围 ID 列表
         :return:
         """
@@ -72,13 +110,16 @@ class UserCacheManager:
         result = await db.execute(stmt)
         user_ids = result.scalars().all()
 
-        await self.clear(user_ids)
+        self.clear(background_tasks, user_ids)
 
-    async def clear_by_data_rule_id(self, db: AsyncSession, rule_ids: list[int]) -> None:
+    async def clear_by_data_rule_id(
+        self, db: AsyncSession, background_tasks: BackgroundTasks, rule_ids: list[int]
+    ) -> None:
         """
         通过数据规则 ID 清理用户缓存
 
         :param db: 数据库会话
+        :param background_tasks: FastAPI 后台任务
         :param rule_ids: 数据规则 ID 列表
         :return:
         """
@@ -92,7 +133,7 @@ class UserCacheManager:
         result = await db.execute(stmt)
         user_ids = result.scalars().all()
 
-        await self.clear(user_ids)
+        self.clear(background_tasks, user_ids)
 
 
 user_cache_manager: UserCacheManager = UserCacheManager()


### PR DESCRIPTION
Fixes #34

## 根因

`user_cache_manager.clear_*()` 系列全部是从 `CurrentSessionTransaction` 端点内部调用的，
而这类端点的事务提交发生在 handler 函数体返回之后（`get_db_transaction` 的
`async with async_db_session.begin()` 在依赖退出时才 commit）。原实现在 DAO 写入之后
直接 `await` 删 Redis，也就是在提交**之前**删——命中这个窗口的并发请求用另一个会话
查库读到的还是旧数据，会把旧快照连同完整 TTL 重新写回 Redis，之后即便事务提交了也
没有人再清一次，缓存（`fba:user:{id}`，筛选侧边栏菜单就靠它）会锁死在旧值上直到 TTL
到期（默认 1 天）。logout 和重新登录都不清这份快照，所以一旦命中没有任何自助恢复路径。

## 修法

- `UserCacheManager` 的 `clear`/`clear_by_role_id`/`clear_by_menu_id`/
  `clear_by_data_scope_id`/`clear_by_data_rule_id` 都改成把真正的 Redis 删除登记为
  `BackgroundTasks`——FastAPI 保证它在依赖退出栈（含 commit）关闭之后、响应发出之前
  才执行，天生晚于提交，不需要额外补一次"提交后清理"
- `role_service` / `menu_service` / `data_scope_service` / `data_rule_service` 里
  所有调用点（13 处）以及对应的 4 个 `api/v1` 路由文件一并改造，逐层传
  `background_tasks` 下去——这正是 issue 里要求的"一次性排查所有 `clear_*` 调用点"
- `logout` 补上删除 `fba:user:{user_id}`，让重新登录重新成为有效的自救手段

## 一个实测抓到的额外 bug

`background_tasks.add_task(redis_client.delete, *keys)` 本身是错的：redis-py 的命令
方法靠元类/注册表动态生成，`asyncio.iscoroutinefunction` 认不出它是协程函数（实测为
`False`）。Starlette 的 `BackgroundTask` 靠这个检测判断要不要 `await`——检测失败就
当成同步函数扔进线程池执行，"执行"一个 async 函数只是创建了一个协程对象、没人
`await` 它，Redis 命令根本不会发出去，只有一条 `coroutine was never awaited` 警告，
没有任何报错。包一层显式的 `async def` 包装函数就没有这个问题。跑端到端测试时第一版
直接踩了这个坑，断言"响应返回后缓存应该已清"失败，才发现的。

## 测试

`test_user_cache_invalidation.py` 三条：
- 单测 `clear()` 确实把删除挂成 background task、不立刻执行（mock 驱动，避开真实
  Redis 连接的跨事件循环问题）
- 端到端：`PUT /sys/roles/{pk}/menus` 返回时，admin 自己的 `fba:user:{id}` 必须已经
  被清——把 `cache.py` 的修复临时改回直接 `await` 版本，这条测试会红（已验证，见下）
- logout 清掉 `fba:user:{user_id}`

全量 `pytest` 201 条通过（原 194 + 本次新增 3 + main 上游新增的其它用例）。

变异验证记录：把 `cache.py` 的 `_delete` 包装函数改回 `background_tasks.add_task(redis_client.delete, *keys)`
这一行，`test_update_role_menus_clears_admin_snapshot_by_the_time_response_returns` 会
可靠地失败（并伴随 `coroutine was never awaited` 警告）；改回修复版本后三条全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)