### PR TITLE
fix(security): 公开上传子树拒绝 SVG，堵住存储型 XSS

### DIFF
--- a/apps/api/backend/app/admin/service/file_service.py
+++ b/apps/api/backend/app/admin/service/file_service.py
@@ -13,7 +13,7 @@ from backend.common.exception import errors
 from backend.common.i18n import t
 from backend.common.log import log
 from backend.common.pagination import paging_data
-from backend.utils.file_ops import delete_file, upload_file, upload_file_verify, upload_root
+from backend.utils.file_ops import delete_file, get_file_ext, upload_file, upload_file_verify, upload_root
 
 
 class FileService:
@@ -59,10 +59,18 @@ class FileService:
         file_select = await file_dao.get_select(name, type, ext, created_by, start_time, end_time)
         return await paging_data(db, file_select)
 
+    # 🔴 SVG 是可执行的 XML 文档（能带 <script>/onload），落进无鉴权的 /uploads
+    # 静态子树、被当成独立文档直接导航打开，就是一个完整的存储型 XSS —— 能读到
+    # sessionStorage 里的 access token（token-store.ts 就存在这里）。`ico` 是纯
+    # 二进制图标格式，没有脚本执行面，不受影响。前端 file-icon.tsx 的
+    # canThumbnail 早就因为同样的理由把 svg 排除在缩略图之外，但那个认知没有
+    # 延伸到"能不能进公开子树"这条更危险的路径——这里补上。
+    _PUBLIC_UNSAFE_IMAGE_EXTS = frozenset({'svg'})
+
     @staticmethod
-    def verify_public(file_type: FileType) -> None:
+    def verify_public(file_type: FileType, file_ext: str) -> None:
         """
-        公开子树的准入校验：**只有图片进得去**。
+        公开子树的准入校验：**只有图片进得去，且不能是可执行的图片格式**。
 
         校验放在 service 而不是接口层，也不靠调用方自觉 —— 公开子树被
         `/uploads` 无鉴权挂出去，一旦让文档/压缩包进去，
@@ -74,9 +82,10 @@ class FileService:
         不是「它是图片」的推论。所以这里只否掉非图片，不代替调用方做决定。
 
         :param file_type: 上传物的分类
+        :param file_ext: 小写扩展名，不带点
         :return:
         """
-        if file_type != FileType.image:
+        if file_type != FileType.image or file_ext in FileService._PUBLIC_UNSAFE_IMAGE_EXTS:
             raise errors.RequestError(msg=t('error.file.public_link_images_only'))
 
     @staticmethod
@@ -94,7 +103,7 @@ class FileService:
         # 先否掉再落盘 —— 反过来的话非法文件已经写进公开目录了，
         # 就算接着 raise，那个可读的直链在磁盘上已经存在过一瞬
         if public:
-            FileService.verify_public(file_type)
+            FileService.verify_public(file_type, get_file_ext(file))
 
         saved = await upload_file(file, public=public)
 

--- a/apps/api/backend/app/admin/tests/api_v1/test_file.py
+++ b/apps/api/backend/app/admin/tests/api_v1/test_file.py
@@ -30,6 +30,11 @@ FILES = '/sys/files'
 # ─── 测试用文件 ────────────────────────────────────────────────────────────────
 
 
+def _svg_bytes() -> bytes:
+    """一段"看起来是图片、实则可执行"的 SVG —— issue #56 的攻击样本"""
+    return b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+
+
 def _png_bytes(color: tuple[int, int, int] = (200, 30, 30)) -> bytes:
     """手搓一个 2x2 PNG —— 不为了一个 fixture 引 Pillow"""
     import struct
@@ -522,3 +527,75 @@ def test_delete_rejects_escaping_path(isolated_upload_dir: Path) -> None:
     delete_file('')
     delete_file('.')
     assert isolated_upload_dir.is_dir()
+
+
+# ─── 公开子树的准入（issue #56：SVG 存储型 XSS） ────────────────────────────────
+
+
+def test_public_upload_rejects_svg(client: TestClient, token_headers: dict[str, str]) -> None:
+    """SVG 不能进公开无鉴权子树 —— 即使 core/conf.py 把它算作"图片"
+
+    SVG 是可执行的 XML 文档，落进 `/uploads` 被当独立文档直接导航打开，
+    就是一个完整的存储型 XSS。回归测试钉住：请求必须被拒绝，且不能有
+    `sys_file` 记录被创建（`verify_public` 必须在落盘*之前*就否掉）。
+    """
+    resp = client.post(
+        f'{FILES}/upload',
+        headers=token_headers,
+        params={'public': True},
+        files={'file': ('logo.svg', _svg_bytes(), 'image/svg+xml')},
+    )
+    assert resp.status_code != 200, 'SVG 走 public=true 必须被拒绝'
+
+    # 确认没有留下孤儿记录：按同一个 sha256 查重应该查不到
+    import hashlib
+
+    sha256 = hashlib.sha256(_svg_bytes()).hexdigest()
+    check = client.get(f'{FILES}/check', headers=token_headers, params={'sha256': sha256})
+    assert check.json()['data'] is None, '被拒绝的公开 SVG 不应该在 sys_file 里留下记录'
+
+
+def test_public_upload_still_accepts_png(client: TestClient, token_headers: dict[str, str]) -> None:
+    """回归对照组：真正的图片走 public=true 必须还能成功
+
+    只测"SVG 被拒绝"不够——不能顺手把合法的公开图片路径也堵死。
+    """
+    upload_resp = client.post(
+        f'{FILES}/upload',
+        headers=token_headers,
+        params={'public': True},
+        files={'file': ('cover.png', _png_bytes(), 'image/png')},
+    )
+    assert upload_resp.status_code == 200, upload_resp.text
+    data = upload_resp.json()['data']
+    try:
+        assert data['is_public'] is True
+        assert data['public_url'], '公开图片必须带 public_url'
+    finally:
+        client.request('DELETE', FILES, headers=token_headers, json={'pks': [data['id']]})
+
+
+def test_public_uploads_static_mount_sets_hardening_headers(tmp_path: Path) -> None:
+    """`/uploads` 挂载必须带 `X-Content-Type-Options`/CSP —— 纵深防御的第二道闸
+
+    不经过完整 app（`app.mount` 在应用启动时就把目录烤进了 StaticFiles 实例，
+    没法用 `isolated_upload_dir` 那套 monkeypatch 顶替），直接单测
+    `_PublicUploadsStaticFiles` 这个类本身：即便以后有格式绕过了
+    `verify_public`，这层头也是第二道防线。
+    """
+    from backend.core.registrar import _PublicUploadsStaticFiles
+
+    (tmp_path / 'cover.png').write_bytes(_png_bytes())
+    app = _PublicUploadsStaticFiles(directory=tmp_path)
+
+    # ⚠️ 不能用 `with TestClient(app) as ...`——那会触发 lifespan 握手，
+    # 而 `StaticFiles.__call__` 只认 `scope["type"] == "http"`，会在
+    # lifespan scope 上直接 assert 失败。这个类只当 sub-app 被 `app.mount()`
+    # 挂在一个完整应用下面，lifespan 由外层应用接管；这里只测 HTTP 请求路径，
+    # 不进 `with` 块就不会有 lifespan 事件。
+    static_client = TestClient(app)
+    resp = static_client.get('/cover.png')
+    assert resp.status_code == 200
+    assert resp.content == _png_bytes()
+    assert resp.headers['x-content-type-options'] == 'nosniff'
+    assert 'content-security-policy' in resp.headers

--- a/apps/api/backend/core/registrar.py
+++ b/apps/api/backend/core/registrar.py
@@ -11,10 +11,12 @@ from fastapi import Depends, FastAPI
 from fastapi_pagination import add_pagination
 from prometheus_client import make_asgi_app
 from sqlalchemy import text
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 from starlette.staticfiles import StaticFiles
+from starlette.types import Receive, Scope, Send
 from starlette_context.middleware import ContextMiddleware
 from starlette_context.plugins import RequestIdPlugin
 
@@ -91,14 +93,16 @@ async def _verify_production_database() -> None:
                 )
 
         seeded = (
-            await db.execute(
-                select(User.username).where(User.password.in_(SEEDED_PASSWORD_HASHES), User.deleted == 0)
+            (
+                await db.execute(
+                    select(User.username).where(User.password.in_(SEEDED_PASSWORD_HASHES), User.deleted == 0)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         if seeded:
-            problems.append(
-                f'这些账号仍在使用种子数据里的默认密码（123456）：{sorted(seeded)} —— 改掉之后再启动'
-            )
+            problems.append(f'这些账号仍在使用种子数据里的默认密码（123456）：{sorted(seeded)} —— 改掉之后再启动')
 
     if problems:
         lines = '\n'.join(f'  {i}. {p}' for i, p in enumerate(problems, 1))
@@ -251,6 +255,27 @@ def register_health(app: FastAPI) -> None:
         )
 
 
+class _PublicUploadsStaticFiles(StaticFiles):
+    """`/uploads` 公开子树的纵深防御：加 `X-Content-Type-Options` + 限制性 CSP
+
+    (issue #56) SVG 已经在 `FileService.verify_public()` 里被挡在准入门槛外，
+    这里不指望单一防线——万一以后有人往 `UPLOAD_IMAGE_EXT_INCLUDE` 加了别的
+    可执行图片格式，`nosniff` 挡掉 MIME 嗅探绕过，`script-src 'none'` 让即便
+    渗进来的文档也执行不了脚本。这棵子树只用来给 `<img src>` 加载，没有任何
+    功能需要内联脚本/样式，所以这条 CSP 可以直接锁到最紧。
+    """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        async def send_wrapper(message: dict) -> None:
+            if message['type'] == 'http.response.start':
+                headers = MutableHeaders(raw=message['headers'])
+                headers['X-Content-Type-Options'] = 'nosniff'
+                headers['Content-Security-Policy'] = "default-src 'none'; sandbox"
+            await send(message)
+
+        await super().__call__(scope, receive, send_wrapper)
+
+
 def register_static_file(app: FastAPI) -> None:
     """
     注册静态资源服务
@@ -285,7 +310,7 @@ def register_static_file(app: FastAPI) -> None:
     # 顺带白拿 StaticFiles 的 ETag / Last-Modified —— 同一张图重复浏览不重复传字节。
     if not os.path.exists(PUBLIC_UPLOAD_DIR):
         os.makedirs(PUBLIC_UPLOAD_DIR)
-    app.mount('/uploads', StaticFiles(directory=PUBLIC_UPLOAD_DIR), name='uploads')
+    app.mount('/uploads', _PublicUploadsStaticFiles(directory=PUBLIC_UPLOAD_DIR), name='uploads')
 
     # 固有静态资源
     if settings.FASTAPI_STATIC_FILES:


### PR DESCRIPTION
Fixes #56

## 根因

`verify_public` 只按扩展名分类判断"是不是图片"，而 `UPLOAD_IMAGE_EXT_INCLUDE` 把 svg/ico 也算作图片。SVG 本身是可执行的 XML 文档（能带 `<script>`/`onload`），一旦落进无鉴权的 `/uploads` 静态子树、被当独立文档直接导航打开，就是一个完整的存储型 XSS——能读到 sessionStorage 里的 access token。

## 修法

- `FileService.verify_public` 现在同时检查扩展名，`svg` 直接拒绝进公开子树（`ico` 是纯二进制格式，没有脚本执行面，不受影响；私有上传不受影响，只挡"公开无鉴权直链"这一条路径）
- `/uploads` 挂载换成 `_PublicUploadsStaticFiles`，加一层纵深防御：`X-Content-Type-Options: nosniff` + 限制性 CSP（`default-src 'none'; sandbox`）——万一以后有其它可执行格式绕过第一道准入检查，这层还能兜一下

## 测试

- `test_public_upload_rejects_svg`：SVG 走 `?public=true` 必须被拒绝，且不留孤儿 `sys_file` 记录（变异验证：把修复临时改回旧版本，这条测试会红，已验证）
- `test_public_upload_still_accepts_png`：回归对照组，确认没有顺手堵死合法的公开图片路径
- `test_public_uploads_static_mount_sets_hardening_headers`：单测 `_PublicUploadsStaticFiles`，确认响应头带 nosniff + CSP

全量 `pytest` 201 条通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)