### PR TITLE
fix(security): 根 .dockerignore 覆盖所有 .env 变体，避免密钥被烤进镜像

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,5 +19,10 @@ apps/web/test-results
 apps/api/backend/log
 apps/api/backend/upload
 apps/api/backend/upload-public
-**/.env
-!**/.env.example
+# 🔴 必须覆盖所有 `.env` 变体（`.env.server`/`.env.e2e`…），不能只挡字面量 `.env`——
+# apps/api/.dockerignore 显式排除的那几个真实密钥文件（backend/.env.e2e、
+# deploy/backend/docker-compose/.env.server）在这份根 ignore 里漏了，
+# `apps/web/Dockerfile` 的构建上下文是仓库根，`COPY . .` 会把它们一起拷进
+# builder 阶段（issue #61：本地/离线构建路径能把生产库密码读出来）。
+**/.env*
+!**/.env*.example


### PR DESCRIPTION
Fixes #61

根 `.dockerignore`（`apps/web/Dockerfile` 的构建上下文用它）之前只排除字面量 `.env`，没覆盖 `.env.server`/`.env.e2e` 这些变体——而这几个正是 `apps/api/.dockerignore` 里显式排除的真实密钥文件（`backend/.env.e2e`、`deploy/backend/docker-compose/.env.server`）。两份 dockerignore 没同步。

按文档流程部署时，第一步是把 `.env.server.example` 复制成 `.env.server` 并填入真实生产库密码/`TOKEN_SECRET_KEY`/SMTP 凭据。走本地/离线构建路径（`docker compose -f docker-compose.prod.yml build`）时，构建 web 镜像的 context 是仓库根，`COPY . .` 会把这些真实密钥文件一并拷进 builder 阶段——即便运行时阶段只 `COPY` 了 `dist/`，builder 阶段的中间层仍留在本机构建缓存里，能被 `docker history` / 挂载中间 stage 读出来。

改成 `**/.env*` + `!**/.env*.example`，和仓库自己的 `.gitignore`（同样是 `.env*` 广义匹配）保持一致，覆盖 `.env.example`/`.env.e2e.example` 两种 example 变体，不排除任何非 `.env` 文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)