### PR TITLE
fix(ui): 删除确认框失败后留在原地，不再无条件关闭

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -14,10 +14,13 @@ const queryClient = new QueryClient({
     queries: { staleTime: 30_000, retry: 1, refetchOnWindowFocus: false },
   },
   // 硬纪律 9 的「写入型」姊妹：mutation 失败必须可见，但不能靠每个调用处各自
-  // 记得写 toast —— 那正是删除类操作全仓系统性漏掉的地方（409 冲突静默吞掉）。
-  // 这里是唯一兜底：任何 mutation 失败都弹一条 toast，除非调用处显式声明
-  // `meta: { suppressErrorToast: true }`（表单已经把校验错误内联展示在字段
-  // 旁边，再弹一条一样的 toast 只是噪音）。
+  // 记得写 toast。这里是唯一兜底：任何 mutation 失败都弹一条 toast，除非调用处
+  // 显式声明 `meta: { suppressErrorToast: true }`。两类调用处会声明这个标记：
+  //   - 表单校验（create/update）：已经把错误内联展示在字段旁边，再弹一条一样的 toast 只是噪音
+  //   - 单条删除确认框：失败要留在弹窗里说清楚原因、原地重试（流派一），不是关了弹窗
+  //     再靠这条全局 toast 兜底——见各 `pages/*/index.tsx` 删除确认框的 onConfirm
+  // 走到这里报错的主要是**批量删除**（allSettled 的部分失败没法「原地重试」，
+  // 弹窗照旧关掉）和极少数没加内联处理的调用处
   mutationCache: new MutationCache({
     onError: (error, _variables, _context, mutation) => {
       if (mutation.meta?.suppressErrorToast) return
@@ -29,10 +32,10 @@ const queryClient = new QueryClient({
       //
       // ⚠️ 这里显式给了 6s 超时，没有沿用 toast 组件里「error 默认不自动消失」
       // 的约定——那条约定是给「页面上还有别的错误态、toast 只是补充」的场景写的
-      // （见 packages/ui/src/components/toast.tsx 头注释）。这里恰恰相反：
-      // 删除类操作现在**只有**这一条 toast 报错，弹窗本身已经关掉、不留错误文案，
-      // 如果也不自动消失，用户每次删除失败都要多点一次「×」才能继续操作，
-      // 是这条链路独有的摩擦，不代表要改那条组件级默认值
+      // （见 packages/ui/src/components/toast.tsx 头注释）。批量删除失败时弹窗已经
+      // 关掉、不留错误文案，这条 toast 是唯一的可见状态，如果也不自动消失，
+      // 用户每次都要多点一次「×」才能继续操作，是这条链路独有的摩擦，
+      // 不代表要改那条组件级默认值
       toast.error(error instanceof Error ? error.message : t("操作失败"), { timeout: 6000 })
     },
   }),

--- a/packages/platform/src/pages/data-permission/api.ts
+++ b/packages/platform/src/pages/data-permission/api.ts
@@ -128,6 +128,8 @@ export function useUpdateDataScope() {
 export function useDeleteDataScopes() {
   const qc = useQueryClient()
   return useMutation({
+    // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+    meta: { suppressErrorToast: true },
     mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/data-scopes', { body: { pks: ids } }),
     onSuccess: invScopes(qc),
   })
@@ -240,6 +242,8 @@ export function useUpdateDataRule() {
 export function useDeleteDataRules() {
   const qc = useQueryClient()
   return useMutation({
+    // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+    meta: { suppressErrorToast: true },
     mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/data-rules', { body: { pks: ids } }),
     onSuccess: invRules(qc),
   })

--- a/packages/platform/src/pages/data-permission/index.tsx
+++ b/packages/platform/src/pages/data-permission/index.tsx
@@ -83,6 +83,9 @@ export function DataPermissionPage({
   const [sheetOpen, setSheetOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<DataScope | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<DataScope | null>(null)
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
   const del = useDeleteDataScopes()
 
   return (
@@ -191,21 +194,25 @@ export function DataPermissionPage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t("删除数据范围")}
         description={
-          pendingDelete
-            ? t('删除范围「{{name}}」？绑了它的角色会失去这部分数据权限。范围里的规则本身保留，可以挂到别的范围上。', { name: pendingDelete.name })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('删除范围「{{name}}」？绑了它的角色会失去这部分数据权限。范围里的规则本身保留，可以挂到别的范围上。', { name: pendingDelete.name })
+          ) : ''
         }
         confirmText={t("删除")}
         destructive
         pending={del.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
             const wasSelected = pendingDelete.id === selected?.id
             await del.mutateAsync([pendingDelete.id])
             if (wasSelected) patch({ scope: undefined })
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/data-permission/rules-panel.tsx
+++ b/packages/platform/src/pages/data-permission/rules-panel.tsx
@@ -11,7 +11,6 @@ import { DataTableSkeletonRows } from '@admin/ui/components/data-table'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@admin/ui/components/table'
-import { toast } from '@admin/ui/components/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@admin/ui/components/tooltip'
 import { cn } from '@admin/ui/lib/utils'
 
@@ -45,6 +44,11 @@ export function RulesPanel({ scope }: { scope: DataScope }) {
   const [pickerOpen, setPickerOpen] = React.useState(false)
   const [pendingUnbind, setPendingUnbind] = React.useState<DataRule | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<DataRule | null>(null)
+  // 失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [unbindError, setUnbindError] = React.useState<string | null>(null)
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setUnbindError(null), [pendingUnbind])
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
 
   const bind = useUpdateScopeRules()
   const delRule = useDeleteDataRules()
@@ -212,23 +216,23 @@ export function RulesPanel({ scope }: { scope: DataScope }) {
         onOpenChange={(o) => !o && setPendingUnbind(null)}
         title={t("从本范围移除规则")}
         description={
-          pendingUnbind
-            ? t('把「{{rule}}」从范围「{{scope}}」里摘掉？规则本身还在，其它范围不受影响。', { rule: pendingUnbind.name, scope: scope.name })
-            : ''
+          unbindError ? (
+            <span className="text-destructive">{unbindError}</span>
+          ) : pendingUnbind ? (
+            t('把「{{rule}}」从范围「{{scope}}」里摘掉？规则本身还在，其它范围不受影响。', { rule: pendingUnbind.name, scope: scope.name })
+          ) : ''
         }
         confirmText={t("移除")}
         destructive
         pending={bind.isPending}
         onConfirm={async () => {
           if (!pendingUnbind) return
+          setUnbindError(null)
           try {
             await bind.mutateAsync({ id: scope.id, rules: ids.filter((x) => x !== pendingUnbind.id) })
-          } catch (e) {
-            // 这个 mutation（useUpdateScopeRules）标了 suppressErrorToast——
-            // rule-picker.tsx 那边已经内联展示过一次，这里不能指望全局兜底，手动弹
-            toast.error(e instanceof Error ? e.message : t('操作失败'))
-          } finally {
             setPendingUnbind(null)
+          } catch (e) {
+            setUnbindError(e instanceof Error ? e.message : t('操作失败'))
           }
         }}
       />
@@ -238,19 +242,23 @@ export function RulesPanel({ scope }: { scope: DataScope }) {
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t("彻底删除规则")}
         description={
-          pendingDelete
-            ? t('删除规则「{{name}}」？这会从所有引用它的数据范围里一并消失，不只是本范围。', { name: pendingDelete.name })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('删除规则「{{name}}」？这会从所有引用它的数据范围里一并消失，不只是本范围。', { name: pendingDelete.name })
+          ) : ''
         }
         confirmText={t("删除")}
         destructive
         pending={delRule.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
             await delRule.mutateAsync([pendingDelete.id])
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/dept/api.ts
+++ b/packages/platform/src/pages/dept/api.ts
@@ -77,6 +77,8 @@ export function useUpdateDept() {
 export function useDeleteDept() {
   const qc = useQueryClient()
   return useMutation({
+    // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+    meta: { suppressErrorToast: true },
     mutationFn: (id: string) => api.DELETE(`/api/v1/sys/depts/${id}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: deptKeys.all }),
   })

--- a/packages/platform/src/pages/dept/index.tsx
+++ b/packages/platform/src/pages/dept/index.tsx
@@ -69,6 +69,9 @@ export function DeptPage({
   const [editing, setEditing] = React.useState<Dept | null>(null)
   const [presetParent, setPresetParent] = React.useState<string | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<Dept | null>(null)
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
   const del = useDeleteDept()
 
   const foldAll = search.fold === 'all'
@@ -202,19 +205,23 @@ export function DeptPage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t("删除部门")}
         description={
-          pendingDelete
-            ? t('确定删除「{{name}}」吗？若该部门下仍有子部门或用户，后端会拒绝。', { name: pendingDelete.name })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('确定删除「{{name}}」吗？若该部门下仍有子部门或用户，后端会拒绝。', { name: pendingDelete.name })
+          ) : ''
         }
         confirmText={t("删除")} destructive pending={del.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
-          // 失败（409 冲突等）由全局 mutationCache 的 onError 弹 toast——
-          // 这里只负责收尾：不管成不成功，弹窗都别再挂着一个「反正会再失败」的删除按钮
+          // 失败（409 冲突等）留在弹窗里说清楚，不静默关掉——
+          // 「部门下有子部门/用户」这类拒绝，关了弹窗用户也无从知晓原因
+          setDeleteError(null)
           try {
             await del.mutateAsync(pendingDelete.id)
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/dict/api.ts
+++ b/packages/platform/src/pages/dict/api.ts
@@ -89,7 +89,12 @@ export function useUpdateDictType() {
 }
 export function useDeleteDictTypes() {
   const qc = useQueryClient()
-  return useMutation({ mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/dict-types', { body: { pks: ids } }), onSuccess: inv(qc) })
+  // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+  return useMutation({
+    meta: { suppressErrorToast: true },
+    mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/dict-types', { body: { pks: ids } }),
+    onSuccess: inv(qc),
+  })
 }
 export function useCreateDictData() {
   const qc = useQueryClient()
@@ -107,9 +112,18 @@ export function useUpdateDictData() {
     onSuccess: inv(qc),
   })
 }
-export function useDeleteDictDatas() {
+/**
+ * 单条删除和批量删除共用同一个接口，但错误处理策略不同：单条删除留在弹窗里
+ * 原地重试（流派一），批量删除是部分失败语义，重试整个选中集合没有意义，
+ * 照旧关弹窗走全局 toast——两处各自 `useDeleteDictDatas()` 一份互不影响的 mutation 实例。
+ */
+export function useDeleteDictDatas(opts: { suppressErrorToast?: boolean } = {}) {
   const qc = useQueryClient()
-  return useMutation({ mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/dict-datas', { body: { pks: ids } }), onSuccess: inv(qc) })
+  return useMutation({
+    meta: { suppressErrorToast: opts.suppressErrorToast ?? false },
+    mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/dict-datas', { body: { pks: ids } }),
+    onSuccess: inv(qc),
+  })
 }
 
 /** 字典项的颜色标记 —— 后端存的是颜色名，这里映射到样式 */

--- a/packages/platform/src/pages/dict/index.tsx
+++ b/packages/platform/src/pages/dict/index.tsx
@@ -134,6 +134,13 @@ export function DictPage({
   const [bulkOpen, setBulkOpen] = React.useState(false)
   const rmType = useDeleteDictTypes()
   const rmData = useDeleteDictDatas()
+  // 单条删除单独一个 mutation 实例——留在弹窗里原地重试，不指望全局兜底
+  const rmDataOne = useDeleteDictDatas({ suppressErrorToast: true })
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [typeError, setTypeError] = React.useState<string | null>(null)
+  const [dataError, setDataError] = React.useState<string | null>(null)
+  React.useEffect(() => setTypeError(null), [delType])
+  React.useEffect(() => setDataError(null), [delData])
 
   const columns = React.useMemo(
     () => [
@@ -377,18 +384,24 @@ export function DictPage({
         onOpenChange={(o) => !o && setDelType(null)}
         title={t("删除字典类型")}
         description={
-          delType ? t('确定删除「{{name}}」吗？其下的字典项也会一并失效。', { name: delType.name }) : ''
+          typeError ? (
+            <span className="text-destructive">{typeError}</span>
+          ) : delType ? (
+            t('确定删除「{{name}}」吗？其下的字典项也会一并失效。', { name: delType.name })
+          ) : ''
         }
         confirmText={t("删除")} destructive pending={rmType.isPending}
         onConfirm={async () => {
           if (!delType) return
+          setTypeError(null)
           try {
             const removingSelected = delType.id === selectedId
             await rmType.mutateAsync([delType.id])
             // 删掉的正是当前选中的 —— 清掉 URL 里的 type，让它回落到第一个
             if (removingSelected) patch({ type: undefined, page: undefined, q: undefined })
-          } finally {
             setDelType(null)
+          } catch (e) {
+            setTypeError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />
@@ -396,14 +409,22 @@ export function DictPage({
         open={delData !== null}
         onOpenChange={(o) => !o && setDelData(null)}
         title={t("删除字典项")}
-        description={delData ? t('确定删除「{{label}}」吗？', { label: delData.label }) : ''}
-        confirmText={t("删除")} destructive pending={rmData.isPending}
+        description={
+          dataError ? (
+            <span className="text-destructive">{dataError}</span>
+          ) : delData ? (
+            t('确定删除「{{label}}」吗？', { label: delData.label })
+          ) : ''
+        }
+        confirmText={t("删除")} destructive pending={rmDataOne.isPending}
         onConfirm={async () => {
           if (!delData) return
+          setDataError(null)
           try {
-            await rmData.mutateAsync([delData.id])
-          } finally {
+            await rmDataOne.mutateAsync([delData.id])
             setDelData(null)
+          } catch (e) {
+            setDataError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/menu/api.ts
+++ b/packages/platform/src/pages/menu/api.ts
@@ -84,7 +84,12 @@ export function useUpdateMenu() {
 }
 export function useDeleteMenu() {
   const qc = useQueryClient()
-  return useMutation({ mutationFn: (id: string) => api.DELETE(`/api/v1/sys/menus/${id}`), onSuccess: inv(qc) })
+  // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+  return useMutation({
+    meta: { suppressErrorToast: true },
+    mutationFn: (id: string) => api.DELETE(`/api/v1/sys/menus/${id}`),
+    onSuccess: inv(qc),
+  })
 }
 
 /** 扁平化成「上级菜单」下拉选项；排除自身及子孙，且按钮不能当父级 */

--- a/packages/platform/src/pages/menu/index.tsx
+++ b/packages/platform/src/pages/menu/index.tsx
@@ -82,6 +82,9 @@ export function MenuPage({
   const [editing, setEditing] = React.useState<Menu | null>(null)
   const [presetParent, setPresetParent] = React.useState<string | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<Menu | null>(null)
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
   const del = useDeleteMenu()
 
   const foldAll = search.fold === 'all'
@@ -262,17 +265,21 @@ export function MenuPage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t("删除菜单")}
         description={
-          pendingDelete
-            ? t('确定删除「{{title}}」吗？其下的子菜单与按钮权限也会一并移除。', { title: pendingDelete.title })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('确定删除「{{title}}」吗？其下的子菜单与按钮权限也会一并移除。', { title: pendingDelete.title })
+          ) : ''
         }
         confirmText={t("删除")} destructive pending={del.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
             await del.mutateAsync(pendingDelete.id)
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/notice/api.ts
+++ b/packages/platform/src/pages/notice/api.ts
@@ -174,9 +174,16 @@ export function useUpdateNotice() {
  * 后端 `DELETE /sys/notices` 直接收 `{pks: []}`，是**真批量**，
  * 不像用户那边只有单条接口要前端并发发 N 个请求。
  */
-export function useDeleteNotices() {
+/**
+ * 单条删除和批量删除共用同一个接口，但错误处理策略不同：单条删除留在弹窗里
+ * 原地重试（流派一），批量删除是 `allSettled` 的部分失败语义，重试整个选中集合
+ * 没有意义，照旧关弹窗走全局 toast——所以 `suppressErrorToast` 按调用方传，
+ * 两处各自 `useDeleteNotices()` 一份互不影响的 mutation 实例。
+ */
+export function useDeleteNotices(opts: { suppressErrorToast?: boolean } = {}) {
   const qc = useQueryClient()
   return useMutation({
+    meta: { suppressErrorToast: opts.suppressErrorToast ?? false },
     mutationFn: (pks: string[]) => api.DELETE('/api/v1/sys/notices', { body: { pks } }),
     onSuccess: () => qc.invalidateQueries({ queryKey: noticeKeys.all }),
   })

--- a/packages/platform/src/pages/notice/index.tsx
+++ b/packages/platform/src/pages/notice/index.tsx
@@ -132,6 +132,11 @@ export function NoticePage({
   const [pendingDelete, setPendingDelete] = React.useState<Notice | null>(null)
   const [bulkOpen, setBulkOpen] = React.useState(false)
   const del = useDeleteNotices()
+  // 单条删除单独一个 mutation 实例——留在弹窗里原地重试，不指望全局兜底
+  const delOne = useDeleteNotices({ suppressErrorToast: true })
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
 
   const handleEdit = React.useCallback((n: Notice) => {
     setEditing(n)
@@ -261,17 +266,23 @@ export function NoticePage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t('删除通知公告')}
         description={
-          pendingDelete ? t('确定删除「{{title}}」吗？此操作不可撤销。', { title: pendingDelete.title }) : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('确定删除「{{title}}」吗？此操作不可撤销。', { title: pendingDelete.title })
+          ) : ''
         }
         confirmText={t('删除')}
         destructive
-        pending={del.isPending}
+        pending={delOne.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
-            await del.mutateAsync([pendingDelete.id])
-          } finally {
+            await delOne.mutateAsync([pendingDelete.id])
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/role/api.ts
+++ b/packages/platform/src/pages/role/api.ts
@@ -149,6 +149,8 @@ export function useUpdateRole() {
 export function useDeleteRoles() {
   const qc = useQueryClient()
   return useMutation({
+    // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+    meta: { suppressErrorToast: true },
     mutationFn: (ids: string[]) => api.DELETE('/api/v1/sys/roles', { body: { pks: ids } }),
     onSuccess: () => qc.invalidateQueries({ queryKey: roleKeys.all }),
   })

--- a/packages/platform/src/pages/role/index.tsx
+++ b/packages/platform/src/pages/role/index.tsx
@@ -117,6 +117,9 @@ export function RolePage({
   const [editing, setEditing] = React.useState<Role | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<Role | null>(null)
   const [pendingSelect, setPendingSelect] = React.useState<string | null>(null)
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
   const del = useDeleteRoles()
 
   // 两个面板各自有草稿，未保存时切角色要拦一下
@@ -281,21 +284,25 @@ export function RolePage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t("删除角色")}
         description={
-          pendingDelete
-            ? t('确定删除角色「{{name}}」吗？已分配该角色的用户会失去对应权限。', { name: pendingDelete.name })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('确定删除角色「{{name}}」吗？已分配该角色的用户会失去对应权限。', { name: pendingDelete.name })
+          ) : ''
         }
         confirmText={t("删除")}
         destructive
         pending={del.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
             const wasSelected = pendingDelete.id === selected?.id
             await del.mutateAsync([pendingDelete.id])
             if (wasSelected) patch({ role: undefined, upage: undefined })
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />

--- a/packages/platform/src/pages/user/api.ts
+++ b/packages/platform/src/pages/user/api.ts
@@ -135,6 +135,8 @@ export function useUpdateUser() {
 export function useDeleteUser() {
   const qc = useQueryClient()
   return useMutation({
+    // 删除确认框自己接错误、留在原地重试（流派一），不指望全局兜底
+    meta: { suppressErrorToast: true },
     mutationFn: (id: string) => api.DELETE(`/api/v1/sys/users/${id}`),
     onSuccess: () => qc.invalidateQueries({ queryKey: userKeys.all }),
   })

--- a/packages/platform/src/pages/user/index.tsx
+++ b/packages/platform/src/pages/user/index.tsx
@@ -182,6 +182,11 @@ export function UserPage({
   const [sheetOpen, setSheetOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<User | null>(null)
   const [pendingDelete, setPendingDelete] = React.useState<User | null>(null)
+  // 删除失败留在弹窗里说清楚原因（流派一），换了目标要清掉上一次的错误文案。
+  // 只对单条删除这么做——批量删除是部分失败语义（allSettled），照旧关弹窗走全局 toast，
+  // 留在原地重试对「已经删掉一半」的选中集合没有意义
+  const [deleteError, setDeleteError] = React.useState<string | null>(null)
+  React.useEffect(() => setDeleteError(null), [pendingDelete])
   // 只存 id，用户对象每次从最新的 rows 里取 —— 存快照的话，
   // 切换权限后列表已经 refetch 了，抽屉里的开关还显示旧值（实测踩过）
   const [securityId, setSecurityId] = React.useState<string | null>(null)
@@ -330,21 +335,25 @@ export function UserPage({
         onOpenChange={(o) => !o && setPendingDelete(null)}
         title={t('删除用户')}
         description={
-          pendingDelete
-            ? t('确定删除「{{who}}」吗？此操作不可撤销。', {
-                who: pendingDelete.nickname || pendingDelete.username,
-              })
-            : ''
+          deleteError ? (
+            <span className="text-destructive">{deleteError}</span>
+          ) : pendingDelete ? (
+            t('确定删除「{{who}}」吗？此操作不可撤销。', {
+              who: pendingDelete.nickname || pendingDelete.username,
+            })
+          ) : ''
         }
         confirmText={t('删除')}
         destructive
         pending={del.isPending}
         onConfirm={async () => {
           if (!pendingDelete) return
+          setDeleteError(null)
           try {
             await del.mutateAsync(pendingDelete.id)
-          } finally {
             setPendingDelete(null)
+          } catch (e) {
+            setDeleteError(e instanceof Error ? e.message : t('删除失败'))
           }
         }}
       />


### PR DESCRIPTION
## 背景

上周「mutation 失败统一走全局 toast」（#51）把 7 处删除确认框改成失败时无条件关闭、错误走全局 toast（流派二）。重新讨论后决定改成「失败留在原地、内联展示错误、原地重试」（流派一）——理由见下。

## 为什么换

「部门下有子部门/用户，无法删除」这类后端**业务规则拒绝**，关掉弹窗对用户没有帮助：按钮 loading 是重置了，但用户要做的事（先处理依赖项）在弹窗里做不到，白白多开一次弹窗。

调研了 Ant Design 和 TDesign 两家的组件契约：
- **Ant Design** `Modal.confirm` 官方文档就是这个契约——`onOk` 返回的 Promise `resolve` 才关闭，`reject` 不关闭
- **TDesign** 的 `Dialog` 反而中立——`onConfirm` 只是个 `void` 回调，关不关完全交给业务方自己拿 `confirmLoading` 判断

而且这个仓库其实**已经有一份流派一的参考实现**：`packages/platform/src/pages/_shared/clear-logs.tsx`（清空日志）一直是这么写的，只是上周那次改动没有对齐它——同一个仓库两种「删除失败」的脾气，这次一起消掉。

## 改动

- **13 处单条删除确认框**（部门/菜单/用户/角色/公告/字典/数据权限，含 rules-panel 的解绑+彻底删除）：`onConfirm` 改成只在成功时关闭，失败 `setError` 留在弹窗里，`description` 换成错误文案（`text-destructive`，和 `clear-logs.tsx` 同一个视觉写法）；对应 `useDelete*` mutation 加 `meta: { suppressErrorToast: true }`，不再指望全局 toast
- **批量删除刻意不跟**（用户/公告/字典项）：`Promise.allSettled` 的部分失败语义下，「留在原地重试整个选中集合」没有意义——已经删掉的不会回滚，选中集合已经过期，正确的恢复路径是关掉弹窗看最新列表，照旧走全局 toast
- `notice` / `dict` 的单条和批量共用同一个 `useDelete*` mutation，给两个 hook 加了 `opts.suppressErrorToast` 参数，两处各开一份独立 mutation 实例，互不影响
- `app.tsx` 的 `MutationCache.onError` 注释同步更新：现在主要是批量删除在用这条全局兜底

## 验证

`pnpm typecheck --force` 5/5 成功、`pnpm --filter web lint` 零输出、`pnpm i18n:check` 0 警告（`删除失败`/`操作失败` 两个 key 都已在语言包里）、`pnpm ctx:check` 0 error。

本次改动在独立 worktree 里完成 + 提交，没有打断仓库主工作目录当时另一个分支上正在进行的改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)