### PR TITLE
fix(security): 公开演示账号的种子密码不该被 prod 启动检查拒绝

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -594,12 +594,22 @@ test_init_handles_every_seeded_account` 硬编码断言 `cli.py: _set_admin_pass
 - ID 故意用 `3000000000000000001` 起步的一段独立区间，跟原来 `2048...`/`2049...`
   开头的雪花 ID 肉眼就能分清，不会误以为是同一批
 - 8 个新账号（张伟/李娜/王芳/刘洋/陈静/赵磊/孙强/周敏）密码都是种子密码 `123456`，
-  **故意永远不重置**——公开演示要的就是"随便挑一个账号登录切换视角"，这跟
-  `check_production_settings()` 挡"生产库还在用默认密码"是两回事：这批账号
-  的 hash 已经补进 `password_security.py: SEEDED_PASSWORD_HASHES` 白名单，
-  `test_seeded_password_hashes_cover_every_seeded_account` 会自动扫 `sql/`
-  下所有 `init_*.sql` 里的 bcrypt hash 做对账，加新演示账号时同步补进那份
-  白名单，否则这条测试会红
+  **故意永远不重置**——公开演示要的就是"随便挑一个账号登录切换视角"。
+  🔴 这批账号的 hash 要补进的是 `password_security.py: SEEDED_DEMO_PASSWORD_HASHES`，
+  **不是** `SEEDED_PASSWORD_HASHES`——两份集合语义相反：后者是
+  `registrar.py: _verify_production_database()` 拿去扫全库、命中就拒绝启动的
+  名单（给 admin/test 这类"必须在 prod 前改掉"的账号用），前者才是"永远保持
+  默认密码也没关系"的公开演示账号。**实测事故**：这两份集合曾经合并成一份，
+  往生产库同步完这 8 个演示账号后重启 `api` 容器——启动检查一查到它们就拒绝
+  启动，容器连续崩溃重启 12 次，`web`/`beat` 因为 `depends_on: api: condition:
+  service_healthy` 一直等不到健康的 `api`，卡在 `Created` 没起来，公开演示站点
+  整个 502。应急止血是把这 8 个账号的密码用新随机盐重新哈希一遍（明文照旧
+  `123456`，只是不再和 `SEEDED_PASSWORD_HASHES` 里那个写死的字面量相等），
+  正式修复是拆成两份集合，把 `_verify_production_database()` 的查询钉死在
+  只读 `SEEDED_PASSWORD_HASHES`。`test_seeded_password_hashes_cover_every_seeded_account`
+  会自动扫 `sql/` 下所有 `init_*.sql` 里的 bcrypt hash，对着**两份集合的并集**
+  做覆盖面对账——加新演示账号时补进 `SEEDED_DEMO_PASSWORD_HASHES`，
+  加新的"必须改密码"账号才补进 `SEEDED_PASSWORD_HASHES`，别补错集合
 - 部门编码从 `TEST` 改成了 `HQ`（"总部"）——`sys_data_rule` 里有一条
   "部门编码等于 xxx" 的规则字面量引用着这个编码（`Dept.code = 'HQ'`），
   改编码的同时要同步改这条规则的 `[value]`，两边不同步的话数据权限演示会

--- a/apps/api/backend/app/admin/tests/security/test_prod_config.py
+++ b/apps/api/backend/app/admin/tests/security/test_prod_config.py
@@ -97,9 +97,7 @@ def test_empty_redis_password_is_rejected() -> None:
 def test_rabbitmq_password_only_checked_when_used() -> None:
     """没用 rabbitmq 就不该因为它的口令被卡住 —— 否则这套校验会招人绕过"""
     check_production_settings(_FakeSettings(CELERY_BROKER='redis', CELERY_RABBITMQ_PASSWORD='guest'))
-    assert 'CELERY_RABBITMQ_PASSWORD' in _expect_rejected(
-        CELERY_BROKER='rabbitmq', CELERY_RABBITMQ_PASSWORD='guest'
-    )
+    assert 'CELERY_RABBITMQ_PASSWORD' in _expect_rejected(CELERY_BROKER='rabbitmq', CELERY_RABBITMQ_PASSWORD='guest')
 
 
 def test_security_switches_must_stay_on() -> None:
@@ -163,18 +161,28 @@ def test_current_settings_object_is_a_real_settings() -> None:
 
 
 def test_seeded_password_hashes_cover_every_seeded_account() -> None:
-    """🔴 `SEEDED_PASSWORD_HASHES` 必须覆盖种子 SQL 里**每一个**带密码的账号。
+    """🔴 `SEEDED_PASSWORD_HASHES` ∪ `SEEDED_DEMO_PASSWORD_HASHES` 必须覆盖
+    种子 SQL 里**每一个**带密码的账号。
 
-    prod 启动时 `_verify_production_database()` 拿这份清单扫全库。漏一个账号，
-    那个账号就能带着默认密码 123456 活到生产上，而启动检查一声不吭地放行。
+    两份集合语义相反，别搞混：`SEEDED_PASSWORD_HASHES`（admin/test）是
+    prod 启动时 `_verify_production_database()` 拿去扫全库、命中就拒绝启动的
+    名单；`SEEDED_DEMO_PASSWORD_HASHES`（8 个公开演示账号）密码设计上永远是
+    123456，**不参与**那条查询——查了就是拿自己的检查把公开演示锁死
+    （实测踩过：8 个演示账号进库后重启 api 直接崩溃重启 12 次）。
 
-    反过来漏在另一侧也踩过：`fba init` 原来只重置 admin，`test` 还留着种子密码 ——
-    于是 init 成功、prod 却起不来（被自己的检查挡住）。两边都要对得上，
-    所以这里同时断言「清单覆盖种子」和「init 会处理掉它们」。
+    这条测试只管"扫到的 hash 有没有地方登记"，不管落在哪一份集合里：
+    漏一个账号，它就能带着谁都不知道的默认密码活在种子里而没有任何测试盯着。
+
+    反过来漏在另一侧也踩过：`fba init` 原来只重置 admin，`test` 还留着种子密码——
+    于是 init 成功、prod 却起不来（被自己的检查挡住，这条与
+    `SEEDED_DEMO_PASSWORD_HASHES` 无关，`fba init` 本来就不处理演示账号）。
     """
     import re
 
-    from backend.app.admin.utils.password_security import SEEDED_PASSWORD_HASHES
+    from backend.app.admin.utils.password_security import (
+        SEEDED_DEMO_PASSWORD_HASHES,
+        SEEDED_PASSWORD_HASHES,
+    )
     from backend.core.path_conf import BASE_PATH
 
     hashes_in_seed: set[str] = set()
@@ -183,12 +191,14 @@ def test_seeded_password_hashes_cover_every_seeded_account() -> None:
         hashes_in_seed.update(re.findall(r"'(\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53})'", body))
 
     assert hashes_in_seed, '种子 SQL 里一个 bcrypt hash 都没扫到，正则大概率坏了'
-    missing = sorted(hashes_in_seed - SEEDED_PASSWORD_HASHES)
+    known_hashes = SEEDED_PASSWORD_HASHES | SEEDED_DEMO_PASSWORD_HASHES
+    missing = sorted(hashes_in_seed - known_hashes)
     assert not missing, (
-        f'种子 SQL 里有 {len(missing)} 个密码 hash 不在 SEEDED_PASSWORD_HASHES 里：{missing}\n'
-        '这些账号能带着默认密码活到生产，而 prod 启动检查扫不到它们。\n'
-        '修法：把 hash 补进 backend/app/admin/utils/password_security.py，'
-        '并确认 backend/cli.py 的 _set_admin_password 会处理对应账号。'
+        f'种子 SQL 里有 {len(missing)} 个密码 hash 没有登记：{missing}\n'
+        '这些账号用的是种子默认密码却没人知道。\n'
+        '修法：admin/test 这类"必须在 prod 前改掉"的账号补进 SEEDED_PASSWORD_HASHES，'
+        '并确认 backend/cli.py 的 _set_admin_password 会处理对应账号；'
+        '"永远保持默认密码"的公开演示账号补进 SEEDED_DEMO_PASSWORD_HASHES。'
     )
 
 

--- a/apps/api/backend/app/admin/utils/password_security.py
+++ b/apps/api/backend/app/admin/utils/password_security.py
@@ -20,13 +20,32 @@ password_hash = PasswordHash((BcryptHasher(),))
 # 用它而不是「改种子 SQL 把密码去掉」：种子被 conftest 和整套 E2E 依赖着
 # （`PYTEST_PASSWORD = '123456'`），改掉代价远大于收益。
 # 真正要挡的是「生产库还在用默认密码」，那件事在 prod 启动时查一次就够了。
+#
+# 🔴 只放 admin / test——**不要**把公开演示账号也塞进这一份。
+# 这份集合是 `registrar.py: _verify_production_database()` 的拒绝启动名单，
+# 不是"已知种子密码"的通用登记表；公开演示账号要的是"永远保持 123456"，
+# 跟这份名单的语义（"还在用默认密码，改掉再启动"）正好相反。
+# 之前两者混在一起，8 个演示账号一齐进了这份 frozenset，实测直接把生产库
+# 启动锁死：`_verify_production_database()` 一查到它们就拒绝启动，
+# 而这些账号的密码本来就设计成永远不会被改掉——见下面 `SEEDED_DEMO_PASSWORD_HASHES`
+# 的说明。两份集合的并集才是 `test_seeded_password_hashes_cover_every_seeded_account`
+# 要扫的"种子里出现的所有 123456 hash"，别只改一份漏了那条测试。
 SEEDED_PASSWORD_HASHES: frozenset[str] = frozenset({
     '$2b$12$8y2eNucX19VjmZ3tYhBLcOsBwy9w1IjBQE4SSqwMDL5bGQVp2wqS.',  # admin
     '$2b$12$BMiXsNQAgTx7aNc7kVgnwedXGyUxPEHRnJMFbiikbqHgVoT3y14Za',  # test
-    # 组织架构演示账号（种子 SQL 里补的部门经理/员工/财务/访客几个角色对应的
-    # 账号），密码同样是 123456，故意保留不重置——公开演示要的就是"随便一个
-    # 账号都能直接登录切换视角"。`fba init` 不处理这批账号，见 cli.py 里
-    # `_set_admin_password` 只认 admin/test 两个名字。
+})
+
+# 组织架构演示账号（种子 SQL 里补的部门经理/员工/财务/访客几个角色对应的账号），
+# 密码同样是 123456，**故意永远不重置**——公开演示要的就是"随便一个账号都能
+# 直接登录切换视角"。`fba init` 不处理这批账号，见 cli.py 里 `_set_admin_password`
+# 只认 admin/test 两个名字。
+#
+# 🔴 刻意**不**并进 `SEEDED_PASSWORD_HASHES`：那份是给 prod 启动检查当拒绝名单用的，
+# 这批账号命中了就会把生产库启动锁死（实测：新加 8 个演示账号后重启 api 容器，
+# 连续崩溃重启 12 次，`web`/`beat` 因为在等 api 健康一直卡在 Created，
+# 公开演示站点整个 502）。这份集合只用于种子 hash 的覆盖面对账测试，
+# 不参与 `_verify_production_database()` 的查询。
+SEEDED_DEMO_PASSWORD_HASHES: frozenset[str] = frozenset({
     '$2b$12$Pnvhzs0e1pJ8qyvB9Kkv1em/IpT.46XKEfPqoIoLR2ly8RVCVEcLS',  # zhangwei
     '$2b$12$7xeTTK8azV4xXUGpZY7kBef7pfDj6ilVE1Pkt6VReNH5xd8kCgVEi',  # lina
     '$2b$12$rCfJ7pCZp/CsGhfbBcU9YuXzfYb8xl8Xm7AqSG5u0fiyoetNGInQ.',  # wangfang
@@ -111,6 +130,4 @@ async def validate_new_password(db: AsyncSession, user_id: int, new_password: st
 
     for hist in password_history[: settings.USER_PASSWORD_HISTORY_CHECK_COUNT]:
         if password_verify(new_password, hist.password):
-            raise errors.RequestError(
-                msg=t('error.password.reused', count=settings.USER_PASSWORD_HISTORY_CHECK_COUNT)
-            )
+            raise errors.RequestError(msg=t('error.password.reused', count=settings.USER_PASSWORD_HISTORY_CHECK_COUNT))

--- a/apps/api/backend/core/registrar.py
+++ b/apps/api/backend/core/registrar.py
@@ -62,6 +62,11 @@ async def _verify_production_database() -> None:
     或者从测试环境 dump 一份过来，都不经过 init。这里按 hash 字面量比对兜底，
     无论库是怎么来的都拦得住（种子 hash 是固定盐，三个方言里同一个常量）。
 
+    ⚠️ 只查 `SEEDED_PASSWORD_HASHES`（admin/test），**不查**
+    `SEEDED_DEMO_PASSWORD_HASHES`（公开演示用的 8 个组织架构账号）——后者的密码
+    设计上永远是 123456，查了就是拿自己的这条检查把自己的公开演示功能锁死。
+    实测踩过：两份混在一起时，同步演示账号进库、下次重启 api 就直接崩溃重启。
+
     :return:
     """
     from alembic.script import ScriptDirectory


### PR DESCRIPTION
## 事故
帮用户部署最新版本时，`api` 容器启动即拒绝、连续崩溃重启 12 次，`web`/`beat`
因为 `depends_on: api: condition: service_healthy` 一直卡在 `Created`，
`https://fra.wubunan.com` 整个 502。

## 根因
`_verify_production_database()` 拿 `SEEDED_PASSWORD_HASHES` 当"拒绝启动"名单查
全库，而这份集合把 admin/test 和 8 个"故意永远保持 123456"的公开演示账号混在
一起——语义正好相反：前者是"必须在 prod 前改掉"，后者是"永远不改也没关系"。
往生产库同步完这 8 个演示账号后重启，启动检查一查到它们就拒绝启动。

应急止血（已在生产上执行）：给这 8 个账号的密码换随机盐重新哈希（明文照旧
123456，只是不再和写死的字面量相等），站点已恢复。这个 PR 是正式修复。

## 改了什么
- `SEEDED_PASSWORD_HASHES` 只留 admin/test
- 新拆一份 `SEEDED_DEMO_PASSWORD_HASHES` 放 8 个演示账号，**不**参与
  `_verify_production_database()` 的查询
- `test_seeded_password_hashes_cover_every_seeded_account` 改成对两份集合的
  并集做覆盖面对账
- `apps/api/AGENTS.md` 记录完整事故链路

## 验证
- 194 条 pytest 全绿、ruff 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)