### PR TITLE
feat(task): 每日问候定时任务

### DIFF
--- a/apps/api/backend/app/task/tasks/notification/tasks.py
+++ b/apps/api/backend/app/task/tasks/notification/tasks.py
@@ -1,0 +1,51 @@
+"""每日问候。
+
+顺带验证消息中心链路是否通畅（落库 → 未读数 → socket 推送 → 前端红点），
+但**用户看到的是产品向的问候语，不是一句"探针/测试"字样**——这条会一直跑下去，
+不是临时调试脚手架，文案要经得起长期展示。
+"""
+
+import random
+
+from backend.app.task.celery import celery_app
+from backend.app.task.tasks.base import with_timeout
+from backend.common.log import log
+from backend.database.db import async_db_session
+from backend.plugin.notification.enums import NotificationCategory
+from backend.plugin.notification.service.notification_service import notification_service
+from backend.utils.timezone import timezone
+
+#: 问候语池。每天随机挑一条而不是固定一句，纯粹是为了不让人看腻——
+#: 内容本身不区分工作日/周末，选纯天气/心情向的通用文案，避免「周一加油」
+#: 撞上真的周三这种尴尬
+_GREETINGS = (
+    '新的一天，从查收消息开始，祝你今天工作顺利。',
+    '早安，别忘了看一眼今天的待办，轻装上阵。',
+    '愿你今天的心情，像晴天一样明朗。',
+    '工作再忙，也要记得喝水、按时休息。',
+    '今天也要元气满满，诸事顺利。',
+    '新的一天，新的开始，愿你所有的努力都有回报。',
+    '早上好，今天的你，比昨天更进一步。',
+    '别忘了对自己好一点，工作与生活都值得被认真对待。',
+)
+
+
+@celery_app.task(name='notification.send_daily_greeting')
+@with_timeout()
+async def send_daily_greeting() -> str:
+    """每天挑一条问候语，给全员广播一次。"""
+    today = timezone.now()
+    greeting = random.choice(_GREETINGS)
+
+    async with async_db_session() as db:
+        await notification_service.broadcast(
+            db=db,
+            title=f'每日问候 · {today.strftime("%m月%d日")}',
+            content=greeting,
+            category=NotificationCategory.SYSTEM,
+        )
+        await db.commit()
+
+    msg = f'每日问候已发送（{timezone.to_str(today)}）：{greeting}'
+    log.info(msg)
+    return msg

--- a/apps/api/backend/plugin/notification/service/notification_service.py
+++ b/apps/api/backend/plugin/notification/service/notification_service.py
@@ -126,14 +126,22 @@ class NotificationService:
         return len(recipients)
 
     @staticmethod
-    async def broadcast(*, db: AsyncSession, title: str, content: str, link: str | None = None) -> Notification:
+    async def broadcast(
+        *,
+        db: AsyncSession,
+        title: str,
+        content: str,
+        link: str | None = None,
+        category: NotificationCategory = NotificationCategory.ANNOUNCEMENT,
+    ) -> Notification:
         """
-        发一条全员广播（给别的模块调用，比如公告发布）
+        发一条全员广播（给别的模块调用，比如公告发布 / 每日问候）
 
         :param db: 数据库会话
         :param title: 标题
         :param content: 内容
         :param link: 点击跳转的前端路由
+        :param category: 分类，默认「公告」——调用方不传就是原来的行为
         :return:
         """
         notification = await notification_dao.create(
@@ -141,7 +149,7 @@ class NotificationService:
             CreateNotificationParam(
                 title=title,
                 content=content,
-                category=NotificationCategory.ANNOUNCEMENT,
+                category=category,
                 link=link,
                 recipient_id=None,
             ),

--- a/apps/api/backend/sql/mysql/init_snowflake_test_data.sql
+++ b/apps/api/backend/sql/mysql/init_snowflake_test_data.sql
@@ -68,7 +68,8 @@ values
 insert into task_scheduler (id, name, task, args, kwargs, queue, exchange, routing_key, start_time, expire_time, expire_seconds, type, interval_every, interval_period, crontab, one_off, enabled, total_run_count, last_run_time, remark, created_time, updated_time, deleted, deleted_time)
 values
 (2049629108253622320, '清理历史日志', 'maintenance.prune_logs', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '15 3 * * *', 0, 1, 0, null, '保留 30 天。日志表是全库长得最快的表，不清理会一直涨', '2026-08-22 17:00:00', null, 0, null),
-(2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', 0, 1, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null);
+(2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', 0, 1, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null),
+(2049629108253622322, '每日问候', 'notification.send_daily_greeting', null, null, null, null, null, null, null, null, 1, null, null, '0 9 * * *', 0, 1, 0, null, '每天 9:00 给全员发一条随机问候语，顺带验收消息中心链路（落库/未读数/socket 推送/前端红点）是否通畅', '2026-08-22 17:00:00', null, 0, null);
 
 insert into sys_role (id, code, name, status, is_filter_scopes, remark, created_time, updated_time)
 values

--- a/apps/api/backend/sql/postgresql/init_snowflake_test_data.sql
+++ b/apps/api/backend/sql/postgresql/init_snowflake_test_data.sql
@@ -68,7 +68,8 @@ values
 insert into task_scheduler (id, name, task, args, kwargs, queue, exchange, routing_key, start_time, expire_time, expire_seconds, type, interval_every, interval_period, crontab, one_off, enabled, total_run_count, last_run_time, remark, created_time, updated_time, deleted, deleted_time)
 values
 (2049629108253622320, '清理历史日志', 'maintenance.prune_logs', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '15 3 * * *', false, true, 0, null, '保留 30 天。日志表是全库长得最快的表，不清理会一直涨', '2026-08-22 17:00:00', null, 0, null),
-(2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', false, true, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null);
+(2049629108253622321, '清理任务执行记录', 'maintenance.prune_task_results', null, '{"days": 30}', null, null, null, null, null, null, 1, null, null, '30 3 * * *', false, true, 0, null, '保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', null, 0, null),
+(2049629108253622322, '每日问候', 'notification.send_daily_greeting', null, null, null, null, null, null, null, null, 1, null, null, '0 9 * * *', false, true, 0, null, '每天 9:00 给全员发一条随机问候语，顺带验收消息中心链路（落库/未读数/socket 推送/前端红点）是否通畅', '2026-08-22 17:00:00', null, 0, null);
 
 insert into sys_role (id, code, name, status, is_filter_scopes, remark, created_time, updated_time)
 values

--- a/apps/api/backend/sql/sqlserver/init_snowflake_test_data.sql
+++ b/apps/api/backend/sql/sqlserver/init_snowflake_test_data.sql
@@ -68,7 +68,8 @@ VALUES
 INSERT INTO task_scheduler (id, name, task, args, kwargs, queue, exchange, routing_key, start_time, expire_time, expire_seconds, type, interval_every, interval_period, crontab, one_off, enabled, total_run_count, last_run_time, remark, created_time, updated_time, deleted, deleted_time)
 VALUES
 (2049629108253622320, N'清理历史日志', 'maintenance.prune_logs', NULL, N'{"days": 30}', NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, '15 3 * * *', 0, 1, 0, NULL, N'保留 30 天。日志表是全库长得最快的表，不清理会一直涨', '2026-08-22 17:00:00', NULL, 0, NULL),
-(2049629108253622321, N'清理任务执行记录', 'maintenance.prune_task_results', NULL, N'{"days": 30}', NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, '30 3 * * *', 0, 1, 0, NULL, N'保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', NULL, 0, NULL);
+(2049629108253622321, N'清理任务执行记录', 'maintenance.prune_task_results', NULL, N'{"days": 30}', NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, '30 3 * * *', 0, 1, 0, NULL, N'保留 30 天。celery 自带的 backend_cleanup 不会被装上（DatabaseScheduler 重写了 setup_schedule），必须自己排', '2026-08-22 17:00:00', NULL, 0, NULL),
+(2049629108253622322, N'每日问候', 'notification.send_daily_greeting', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, '0 9 * * *', 0, 1, 0, NULL, N'每天 9:00 给全员发一条随机问候语，顺带验收消息中心链路（落库/未读数/socket 推送/前端红点）是否通畅', '2026-08-22 17:00:00', NULL, 0, NULL);
 
 INSERT INTO sys_role (id, code, name, status, is_filter_scopes, remark, created_time, updated_time)
 VALUES


### PR DESCRIPTION
## 做了什么

新增 celery 任务 `notification.send_daily_greeting`：每天从问候语池里随机挑一条，
给全员广播一次（分类=系统）。三份种子 SQL（mysql/postgresql/sqlserver）都补了对应的
调度（每天 9:00，`id=2049629108253622322`），新装/重置的库自带这条，不用手建。

`notification_service.broadcast()` 顺带加了可选的 `category` 参数（默认仍是「公告」，
公告发布那条现有调用不受影响），让每日问候能落进「系统」分类而不是跟公告混在一起。

## 验证

- `pnpm --filter api test:db` 用新种子重建了 `fba_test`，三份 SQL 都能正常解析灌入
- `test_scheduler*.py`（63 条，含 `test_every_schedule_in_db_points_at_a_registered_task`）全绿
- `notification` 插件测试全绿
- 本地手动 `run now` 触发过一次，确认落库 / 未读数 / REST 读取链路通畅

🤖 Generated with [Claude Code](https://claude.com/claude-code)