### PR TITLE
fix(auth): 会话撤销要连 refresh token 一起，登出也认 refresh cookie

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -105,6 +105,51 @@
 `sqlserver` 已经补进枚举。**以后 cherry-pick 上游改动碰到这个文件时，
 记得别把它覆盖回去。**
 
+### 🔴 撤销一个会话 = 删三个 key，漏掉 refresh 那个等于没撤销
+
+`create_new_token()` 只校验「refresh key 存在且值相等」，**从不检查 access key 还在不在**。
+所以只要 `fba:refresh_token:{uid}:{sid}` 还活着，那个会话就能随时换回一个全新的 access token。
+两个入口都栽在这上面（两个都是**静默**的，界面上该消失的都消失了，人还在）：
+
+| 入口 | 原来的样子 | 后果 |
+|---|---|---|
+| **强制下线**（`monitor/online.py: delete_session` → `jwt.py: revoke_token`） | 只删 `TOKEN_REDIS_PREFIX` 和 `TOKEN_EXTRA_INFO_REDIS_PREFIX` | 被踢的人立刻打一次 `/auth/refresh` 就回来了；而此时 `token_keys` 恰好是空的，`multi_login` 那道检查**反而更不会拦** |
+| **登出**（`auth_service.logout`） | 第一句 `get_token(request)`，拿不到 `Authorization: Bearer` 直接 `return` | 见下 |
+
+`revoke_token()` 现在三个 key 一起删。**新增任何「让某个会话失效」的代码时，
+判据是「它还能不能刷出新 token」，不是「在线用户页上还在不在」。**
+
+### 🔴 登出的身份要从 access token **或** refresh cookie 里任取其一
+
+原来只认 access token，于是两类调用方的登出**全都是空操作**，而两边都看不出来：
+
+- **桌面端**：`apps/desktop/src/main/auth.ts` 的 `logout` 只手工带 cookie、不带
+  Authorization —— access token 在渲染层的 sessionStorage 里，主进程手上根本没有。
+  它本地删了凭据、界面也回到登录页，而那个会话的 refresh token 还能再活 7 天
+- **浏览器端**：access token 过期之后点登出，JWT 中间件先 401，请求根本到不了
+  `logout()`，连 `response.delete_cookie` 都没执行 —— 浏览器里那个 httpOnly cookie
+  既没被清、在 Redis 里也仍然有效。**而那恰恰是最需要登出的时刻**
+
+refresh token 的 JWT 里同样带着 `sub` 和 `session_uuid`（`create_refresh_token`），
+它自己就够定位一个会话。安全性不受影响：一种凭据都拿不出时什么都不做，
+拿得出也只能撤销**它自己那一个**会话。
+
+⚠️ **不要顺手把 `/auth/logout` 加进 `TOKEN_REQUEST_PATH_EXCLUDE`。** 我试过，
+为的是让「access token 已过期时点登出」也进得来 —— 但那条路由是**要记操作日志**的，
+白名单会让 `request.user` 变成未认证，`opera_log_middleware` 的 `request.user.username`
+走 AttributeError 分支，**每一次登出都记不下用户名**。而它买到的只有那一种情况，
+且前端的 401 → 单飞刷新 → 重放已经覆盖了（刷新时 `create_new_token()` 自己就会删掉
+旧会话的 access + refresh key）。
+只带 cookie 的请求本来就过得了中间件：`extract_token()` 没有 Authorization 头时返回
+`None`，那是「未认证」而不是「认证失败」。
+
+⚠️ 写这类测试**不能用 `/auth/login/swagger`**：它只发 access token，
+`create_refresh_token` 根本没被调用（`auth_service.swagger_login`），
+拿它测 refresh 撤销等于什么都没测。要走真实 `/auth/login`，
+并且把 `load_login_config` 一起顶掉 —— 只设 `settings.LOGIN_CAPTCHA_ENABLED = False`
+会被它从 sys_config 表里 setattr 回来，而那张表在 `fba_test` 里是什么值
+取决于上一次 E2E 的 global-setup 跑没跑过。
+
 ## 数据库结构改动一律走 alembic
 
 **改了模型就要生成迁移，没有例外。** 手写 `ALTER` / `drop_all` 重建那条路已经关了

--- a/apps/api/backend/app/admin/service/auth_service.py
+++ b/apps/api/backend/app/admin/service/auth_service.py
@@ -24,6 +24,7 @@ from backend.common.security.jwt import (
     create_refresh_token,
     get_token,
     jwt_decode,
+    revoke_token,
 )
 from backend.core.conf import settings
 from backend.database.db import uuid4_str
@@ -299,25 +300,49 @@ class AuthService:
         """
         用户登出
 
+        🔴 **会话身份从 access token 或 refresh cookie 里任取其一，不能只认前者。**
+        原来这里第一句就是 `get_token(request)`，拿不到 `Authorization: Bearer` 直接
+        `return` —— 于是两类调用方的登出**全都是空操作**，而两边都看不出来：
+
+        - **桌面端**（`apps/desktop/src/main/auth.ts` 的 `logout`）只手工带 cookie、
+          不带 Authorization（access token 在渲染层的 sessionStorage 里，主进程手上没有）。
+          它本地删了凭据、界面也回到登录页，但服务端三个 key 一个没删 ——
+          那个会话的 refresh token 还能再活 7 天
+        refresh token 的 JWT 里同样带着 `sub` 和 `session_uuid`
+        （`create_refresh_token`），所以它自己就够定位一个会话。安全性不受影响：
+        没有任何一种凭据时什么都不做，拿得出凭据才撤销**它自己那一个**会话。
+
+        ⚠️ 只带 cookie、不带 Authorization 的请求**本来就过得了 JWT 中间件** ——
+        `extract_token()` 在没有 Authorization 头时返回 `None`，那是「未认证」不是
+        「认证失败」。所以这个修复**不需要**把 `/auth/logout` 加进
+        `TOKEN_REQUEST_PATH_EXCLUDE`（加了反而会让操作日志记不下用户名，见 conf.py 那条注释）。
+
         :param request: FastAPI 请求对象
         :param response: FastAPI 响应对象
         :return:
         """
-        try:
-            token = get_token(request)
-            token_payload = jwt_decode(token)
-            user_id = token_payload.user_id
-            session_uuid = token_payload.session_uuid
-            refresh_token = request.cookies.get(settings.COOKIE_REFRESH_TOKEN_KEY)
-        except errors.TokenError:
-            return
-        finally:
-            response.delete_cookie(settings.COOKIE_REFRESH_TOKEN_KEY)
+        # 无论后面成不成，浏览器里那个 cookie 都要清掉
+        response.delete_cookie(settings.COOKIE_REFRESH_TOKEN_KEY)
 
-        await redis_client.delete(f'{settings.TOKEN_REDIS_PREFIX}:{user_id}:{session_uuid}')
-        await redis_client.delete(f'{settings.TOKEN_EXTRA_INFO_REDIS_PREFIX}:{user_id}:{session_uuid}')
-        if refresh_token:
-            await redis_client.delete(f'{settings.TOKEN_REFRESH_REDIS_PREFIX}:{user_id}:{session_uuid}')
+        identity: tuple[int, str] | None = None
+        for candidate in (
+            # access token 优先：它是「当前这次请求」最直接的身份
+            lambda: get_token(request),
+            lambda: request.cookies.get(settings.COOKIE_REFRESH_TOKEN_KEY) or '',
+        ):
+            try:
+                payload = jwt_decode(candidate())
+            except errors.TokenError:
+                continue
+            identity = (payload.user_id, payload.session_uuid)
+            break
+
+        if identity is None:
+            # 两种凭据都没有或都无效 —— 登出本来就该是幂等的，静默成功
+            return
+
+        user_id, session_uuid = identity
+        await revoke_token(user_id, session_uuid)
         # 🔴 见 issue #34：这份用户快照（menu_service.get_sidebar 用它筛菜单）原来
         # 只被 user_cache_manager.clear_* 显式作废，logout 从不碰它——一旦它被卡在
         # 旧值上（比如另一个管理员改权限的请求撞上了竞态），重新登录并不能重建它，

--- a/apps/api/backend/app/admin/tests/api_v1/test_auth.py
+++ b/apps/api/backend/app/admin/tests/api_v1/test_auth.py
@@ -168,3 +168,139 @@ def test_swagger_login_is_not_registered_in_prod(env: str) -> None:
         settings.ENVIRONMENT = original
         # 还原模块状态，否则后面的用例会跑在 prod 版路由表上
         importlib.reload(importlib.import_module('backend.app.admin.api.v1.auth.auth'))
+
+
+# ─── 会话撤销：登出与强制下线 ─────────────────────────────────────────────────
+#
+# 这一组守的是同一件事：**撤销一个会话时 refresh token 必须一起死。**
+# 两个 bug 都是静默的 —— 界面上该消失的都消失了，人还在。
+
+
+@pytest.fixture
+def no_captcha(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """让 `/auth/login` 不走验证码
+
+    ⚠️ 光设 `settings.LOGIN_CAPTCHA_ENABLED = False` 不够：`login()` 第一句就是
+    `await load_login_config(db)`，它会把 **sys_config 表里的值** setattr 回 settings
+    （`utils/dynamic_config.py`）。而那张表在 fba_test 里是什么值，取决于上一次
+    E2E 的 global-setup 有没有跑过 —— 依赖它就是依赖一个看不见的外部状态。
+    所以连那次加载一起顶掉。
+    """
+
+    async def _noop(_db: object) -> None:  # ruff: ignore[unused-async] - 顶掉的原函数是 async，签名要对上
+        return None
+
+    monkeypatch.setattr('backend.app.admin.service.auth_service.load_login_config', _noop)
+    original = settings.LOGIN_CAPTCHA_ENABLED
+    settings.LOGIN_CAPTCHA_ENABLED = False
+    try:
+        yield
+    finally:
+        settings.LOGIN_CAPTCHA_ENABLED = original
+
+
+@pytest.fixture
+def session(client: TestClient, no_captcha: None) -> Iterator[tuple[dict[str, str], str]]:
+    """走**真实** `/auth/login` 建一个带 refresh cookie 的会话
+
+    返回 `(auth_headers, session_uuid)`；refresh cookie 留在 client 的 jar 里，
+    用例只要**不传 Authorization** 就等价于桌面端发出的那个请求。
+
+    ⚠️ 不能用 `/auth/login/swagger`：它只发 access token，`create_refresh_token`
+    根本没被调用（`auth_service.swagger_login`），拿它来测 refresh 撤销等于什么都没测。
+
+    🔴 **也不能自己再 `TestClient(app)` 开一个。** `TestClient` 作为上下文管理器会
+    跑一遍应用的 lifespan，而 `conftest` 里那个 `client` 是 **session 级**、全程开着的 ——
+    第二个实例退出时的 shutdown 会把共享的 Redis / 数据库连接一起关掉，
+    后面所有用例都受牵连，而报出来的错和这里毫无关系。
+
+    ⚠️ cookie 挂在 client 实例上而不是逐请求传 `cookies=` —— 后者在 httpx 里已废弃
+    （"expected behaviour on cookie persistence is ambiguous"）。代价是它是**共享**的，
+    所以 teardown 必须清干净，否则污染同一 session 里的其它用例。
+    """
+    res = client.post('/auth/login', json={'username': PYTEST_USERNAME, 'password': PYTEST_PASSWORD})
+    assert res.status_code == 200, res.text
+    assert client.cookies.get(settings.COOKIE_REFRESH_TOKEN_KEY), 'login 没下发 refresh cookie —— 后面的断言全是假的'
+
+    data = res.json()['data']
+    try:
+        yield {'Authorization': f'Bearer {data["access_token"]}'}, str(data['session_uuid'])
+    finally:
+        client.cookies.clear()
+
+
+def _keep_refresh_cookie(client: TestClient) -> str:
+    """把当前 refresh cookie 的值抠出来备用
+
+    🔴 **登出的响应带 `delete_cookie`，httpx 会照办**——直接在登出之后打
+    `/auth/refresh`，失败的原因是「压根没带 cookie」，不是「服务端撤销了它」。
+    这条断言会**假绿**：把 `revoke_token()` 里删 refresh key 那行注释掉，它照样通过
+    （实测确认过）。真实客户端手里那份凭据不会因为服务端说一声就消失
+    （桌面端就是自己存在磁盘上的），所以测试必须把它塞回去再验。
+    """
+    value = client.cookies.get(settings.COOKIE_REFRESH_TOKEN_KEY)
+    assert value, '还没登录就取 refresh cookie'
+    return value
+
+
+def _user_id(client: TestClient, headers: dict[str, str]) -> int:
+    res = client.get('/sys/users/me', headers=headers)
+    assert res.status_code == 200, res.text
+    return int(res.json()['data']['id'])
+
+
+def test_force_offline_also_revokes_the_refresh_token(client: TestClient, session: tuple[dict[str, str], str]) -> None:
+    """🔴 回归：强制下线之后，refresh token 必须也失效
+
+    `revoke_token()` 原来只删 access 和附加信息两个 key。而 `create_new_token()`
+    只校验「refresh key 存在且值相等」，**从不检查 access key 还在不在** ——
+    被踢的会话立刻打一次 `/auth/refresh` 就能换回全新的 access token，
+    而此时 `token_keys` 恰好是空的，`multi_login` 那道检查反而更不会拦。
+    在线用户页上那一行确实消失了，人却还在。
+    """
+    headers, session_uuid = session
+    user_id = _user_id(client, headers)
+
+    kicked = client.delete(f'/monitors/sessions/{user_id}', params={'session_uuid': session_uuid}, headers=headers)
+    assert kicked.status_code == 200, kicked.text
+
+    revived = client.post('/auth/refresh')
+    assert revived.status_code != 200, (
+        f'强制下线之后还能刷出新 token（HTTP {revived.status_code}）—— refresh key 没被撤销'
+    )
+
+
+def test_logout_revokes_the_refresh_token(client: TestClient, session: tuple[dict[str, str], str]) -> None:
+    """登出之后拿同一个 refresh cookie 刷新必须失败"""
+    headers, _ = session
+    refresh = _keep_refresh_cookie(client)
+
+    assert client.post('/auth/logout', headers=headers).status_code == 200
+    # 模拟「客户端手里那份凭据还在」：服务端撤销了才算数
+    client.cookies.set(settings.COOKIE_REFRESH_TOKEN_KEY, refresh)
+    assert client.post('/auth/refresh').status_code != 200, '登出之后 refresh token 还活着'
+
+
+def test_logout_works_with_only_the_refresh_cookie(client: TestClient, session: tuple[dict[str, str], str]) -> None:
+    """🔴 回归：没有 Authorization 头、只有 refresh cookie 时，登出也必须真的撤销
+
+    这正是桌面端走的路（`apps/desktop/src/main/auth.ts` 的 logout 只手工带 cookie ——
+    access token 在渲染层的 sessionStorage 里，主进程手上没有）。
+    原来 `logout()` 第一句 `get_token(request)` 拿不到 Bearer 就直接 `return`，
+    三个 key 一个没删：桌面端本地删了凭据、界面也回到登录页，而那个会话的
+    refresh token 还能再活 7 天。
+    """
+
+    refresh = _keep_refresh_cookie(client)
+
+    # 关键：**不带 Authorization**，只有 refresh cookie —— 这就是桌面端发出的那个请求
+    assert client.post('/auth/logout').status_code == 200
+    client.cookies.set(settings.COOKIE_REFRESH_TOKEN_KEY, refresh)
+    assert client.post('/auth/refresh').status_code != 200, '只带 cookie 的登出是空操作，refresh token 还活着'
+
+
+def test_logout_without_any_credential_is_a_silent_noop(client: TestClient) -> None:
+    """两种凭据都没有时，登出要静默成功 —— 它本来就该是幂等的"""
+    res = client.post('/auth/logout')
+    assert res.status_code == 200, res.text
+    assert res.json()['code'] == 200

--- a/apps/api/backend/common/security/jwt.py
+++ b/apps/api/backend/common/security/jwt.py
@@ -167,7 +167,17 @@ async def create_new_token(
 
 async def revoke_token(user_id: int, session_uuid: str) -> None:
     """
-    撤销 token
+    撤销一个会话的**全部**凭据
+
+    🔴 **三个 key 必须一起删，尤其是 refresh key。**
+    原来这里只删 access（`TOKEN_REDIS_PREFIX`）和附加信息，漏了
+    `TOKEN_REFRESH_REDIS_PREFIX` —— 而 `create_new_token()` 只校验
+    「refresh key 存在且值相等」（jwt.py 里那两行），**从不检查 access key 还在不在**。
+    于是「强制下线」（`api/v1/monitor/online.py` 的 `delete_session`）踢掉的会话，
+    只要立刻打一次 `/auth/refresh` 就能换回一个全新的 access token；
+    而此时 `token_keys` 恰好是空的，`multi_login` 那道检查反而更不会拦。
+    表现是「在线用户页点了强制下线、那一行也消失了，人却还在」——
+    界面上没有任何异常，被踢的人也毫无感觉。
 
     :param user_id: 用户 ID
     :param session_uuid: 会话 ID
@@ -175,6 +185,7 @@ async def revoke_token(user_id: int, session_uuid: str) -> None:
     """
     await redis_client.delete(f'{settings.TOKEN_REDIS_PREFIX}:{user_id}:{session_uuid}')
     await redis_client.delete(f'{settings.TOKEN_EXTRA_INFO_REDIS_PREFIX}:{user_id}:{session_uuid}')
+    await redis_client.delete(f'{settings.TOKEN_REFRESH_REDIS_PREFIX}:{user_id}:{session_uuid}')
 
 
 def get_token(request: Request) -> str:

--- a/apps/api/backend/core/conf.py
+++ b/apps/api/backend/core/conf.py
@@ -111,6 +111,14 @@ class Settings(BaseSettings):
     TOKEN_REQUEST_UNDERLYING_SECURITY: bool = True
     TOKEN_REQUEST_PATH_EXCLUDE: list[str] = [  # JWT / RBAC 路由白名单
         f'{FASTAPI_API_V1_PATH}/auth/login',
+        # ⚠️ **不要**把 `/auth/logout` 加进来。曾经加过，为的是让「access token 已过期
+        # 时点登出」不被中间件 401 挡住 —— 但代价是 `request.user` 在这条路由上变成
+        # 未认证，`opera_log_middleware` 的 `request.user.username` 走 AttributeError
+        # 分支，**每一次登出的操作日志都记不下用户名**（那张表本来就是审计用的）。
+        # 而它买到的只有那一种情况，且前端的 401 → 单飞刷新 → 重放已经覆盖了：
+        # 刷新时 `create_new_token()` 自己就会删掉旧会话的 access + refresh key。
+        # 只带 cookie、不带 Authorization 的请求（桌面端）本来就过得了中间件 ——
+        # `extract_token()` 没有 Authorization 头时返回 None，是「未认证」不是「认证失败」。
     ]
     TOKEN_REQUEST_PATH_EXCLUDE_PATTERN: list[Pattern[str]] = []  # JWT / RBAC 路由白名单（正则）
 

--- a/apps/desktop/src/main/auth.ts
+++ b/apps/desktop/src/main/auth.ts
@@ -160,6 +160,18 @@ export async function restore(): Promise<AuthTokens | null> {
   }
 }
 
+/**
+ * 登出。
+ *
+ * 🔴 这里**只带 cookie、不带 `Authorization`** —— access token 在渲染层的
+ * sessionStorage 里，主进程手上没有。这依赖后端 `auth_service.logout()` 能从
+ * **refresh cookie** 里取出会话身份（`sub` + `session_uuid` 就在那个 JWT 里）。
+ *
+ * 后端曾经只认 access token（第一句 `get_token(request)` 拿不到 Bearer 就 `return`），
+ * 于是这个请求是**彻底的空操作**：本地凭据删了、界面也回到登录页，而服务端三个 key
+ * 一个没删，那个会话的 refresh token 还能再活 7 天。两边都看不出异常。
+ * 回归测试钉在 `test_auth.py::test_logout_works_with_only_the_refresh_cookie`。
+ */
 export async function logout(): Promise<void> {
   const token = loadRefreshToken()
   clearRefreshToken()


### PR DESCRIPTION
Closes #84

排查 `apps/mobile` 接入方案时顺带挖出来的两个**已存在**的洞，和移动端无关，web / desktop 都中招。

## 两个洞

| 入口 | 界面表现 | 实际 |
|---|---|---|
| 在线用户页「强制下线」 | 那一行消失了 | 被踢的人打一次 `/auth/refresh` 就换回全新 access token |
| 桌面端「退出登录」 | 回到登录页、本地凭据也删了 | 服务端三个 key **一个都没删**，refresh 还能活 7 天 |

**根因一**：`revoke_token()` 漏删 `TOKEN_REFRESH_REDIS_PREFIX`，而 `create_new_token()` 只校验 refresh key、**从不检查 access key 还在不在**。更糟的是此时 `token_keys` 恰好是空的，`multi_login` 那道检查反而更不会拦。

**根因二**：`logout()` 第一句 `get_token(request)` 拿不到 Bearer 直接 `return`。桌面端只手工带 cookie —— access token 在渲染层的 sessionStorage 里，主进程手上根本没有（那是它的架构决定的，不是写错了）。

## 修法

1. `revoke_token()` 三个 key 一起删
2. `logout()` 的会话身份从 access token **或** refresh cookie 任取其一（refresh 的 JWT 里同样带着 `sub` 和 `session_uuid`），统一走 `revoke_token()`

安全性不变：一种凭据都拿不出就什么都不做，拿得出也只能撤销它自己那一个会话。

## 试过但撤掉的一步

一度把 `/auth/logout` 加进 `TOKEN_REQUEST_PATH_EXCLUDE`，为的是让「access token 已过期时点登出」也进得来。撤掉是因为**那条路由要记操作日志**——白名单会让 `request.user` 变成未认证，`opera_log_middleware` 的 `request.user.username` 走 AttributeError 分支，**每次登出都记不下用户名**。而它买到的只有那一种情况，前端的 401 → 单飞刷新 → 重放已经覆盖了。

## 测试

新增 4 条，**做过变异验证**：
- 去掉 `revoke_token()` 里删 refresh key 那行 → 3 条红
- `logout()` 退回「只认 access token」 → 桌面端那条红

⚠️ 第一版测试是**假绿**：登出响应带 `delete_cookie`，httpx 会照办，于是「登出后 refresh 失败」失败的原因是压根没带 cookie。现在会把客户端手里那份塞回去再验——真实客户端的凭据不会因为服务端说一声就消失。

pytest 231 passed（+4），e2e 53 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
