### PR TITLE
fix(seed): 种子数据补上追加机制，并补齐已存在库缺的那几行

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -236,6 +236,48 @@ autogenerate 渲染不出 Python 侧的 `default=`** —— 它写出来的是�
 `'dict' object has no attribute 'id'` → 500。用 `item['id']`，
 往 dict 里塞新键即可，FastAPI 那层照样按 response_model 校验得过。
 
+### 🔴 改了种子 SQL，已存在的库不会跟上 —— 要补一条 data migration（issue #86）
+
+schema 和种子数据走的是**两条完全不同的路**：
+
+| | 谁执行 | 已存在的库会不会跟上 |
+|---|---|---|
+| schema | 部署时 `alembic upgrade head` | ✅ 会，且 `test_model_matches_migrations` 兜着「忘了生成迁移」 |
+| **种子数据** | 只有 `fba init`（`drop_all` + `create_all` + 灌种子 + `stamp head`） | 🔴 **不会。** 没有版本号、没有「这批种子进过这个库吗」的记录 |
+
+**漏过两次，两次都是真的用户可见回归**：`5c1d594` 加的三条 RBAC 权限锚点菜单从没进
+生产库，而校验在部署那一刻就生效了 —— MANAGER 演示账号原本能看的部门树当场 403；
+`256beae` 加的「每日问候」调度同理，功能部署了、从来没跑过。
+
+**机制就是普通的 alembic revision**，只是 `upgrade()` 里不是 DDL 而是幂等 INSERT。
+白拿三样：`alembic_version` 天然记录每个库跑到哪、部署已经在跑 `upgrade head`、
+`fba init` 末尾的 `stamp head` 会把它标成已应用而**不执行**（新库的行来自种子 SQL，
+不会插两遍）。helper 在 `backend/utils/data_migration.py`，样板见
+`alembic/versions/*33ffb491b69f*.py`。
+
+三条纪律：
+
+- 🔴 **外键按业务键解析，不要硬编码 ID。** `sys_menu.name` / `sys_role.code` 这类键
+  跨环境稳定；而三个方言的种子各有一套 ID（postgresql 的角色在 `4000000000000000xxx`、
+  另两个在 `3000000000000000xxx`），生产库的 ID 又只在生产库里成立
+- 🔴 **幂等靠业务键判存在，不要吃唯一约束冲突** —— 三种方言的冲突语法各不相同
+  （`MERGE` / `ON CONFLICT` / `INSERT IGNORE`），写任一种都会在另外两种上炸
+- 🔴 **不要在数据迁移里调 `snowflake.generate()`。** 它要读环境变量或去 Redis 抢节点号，
+  而 `alembic upgrade` 是部署时一个独立的 `migrate` 容器 —— 把 Redis 变成它的前置依赖
+  是个新耦合，失败时还报「雪花 ID 生成失败」，完全看不出跟数据迁移有关。
+  有语义的行（菜单）**照抄种子里那个 ID**（三个方言的 `sys_menu` 是同一套，抄过来能让
+  「升级上来的库」和「新建的库」收敛）；纯连接行（`sys_role_menu`）用
+  `DATA_MIGRATION_PK_BASE` 那一段
+- ⚠️ **不要重新灌整份种子** —— 会把别人在界面上改过的数据覆盖回去。只补「按业务键查不到」的行
+
+守卫是 `test_seed_files_have_a_matching_data_migration_decision`：种子文件的 sha256
+变了而 `backend/sql/seed_manifest.json` 没更新就红。它**证明不了**那条迁移真的插了
+同样的行，只强迫你看一眼并做决定（和 `test_every_crud_class_declares_its_data_scope_stance`
+同一个物种）。确认过之后 `pnpm --filter api seed:manifest --write` 更新清单。
+
+⚠️ 清单覆盖**插件的 `sql/` 也算** —— `#81` 的消息中心菜单就是从插件那份漏掉的，
+机制和漏法与基础种子一模一样。
+
 ## 后端国际化（i18n）
 
 语言包在 `backend/locale/{zh-CN,en-US}.yml`，**统一用 YAML**（2026-08-22 前

--- a/apps/api/backend/alembic/versions/20260831_1427-33ffb491b69f_补齐已存在库缺的种子行_rbac_权限锚点_消息中心菜单.py
+++ b/apps/api/backend/alembic/versions/20260831_1427-33ffb491b69f_补齐已存在库缺的种子行_rbac_权限锚点_消息中心菜单.py
@@ -1,0 +1,125 @@
+"""补齐已存在库缺的种子行（RBAC 权限锚点 / 消息中心菜单）
+
+Revision ID: 33ffb491b69f
+Revises: 9609aedfaf8d
+Create Date: 2026-08-31 14:27:41.748755+08:00
+
+issue #86。种子数据只在 `fba init`（从零建库）那条路径上跑一次，一个已经存在的库
+再也不会重新执行那份 SQL —— 没有版本号、也没有任何检查会发现「种子改了但某个
+正在跑的库没跟上」。实际后果：
+
+- `5c1d594` 加的三条 RBAC 权限锚点菜单从没进生产库，而**校验在部署那一刻就生效了** ——
+  MANAGER 演示账号原本能看的部门树当场 403
+- `#81` 的消息中心菜单同理：功能上线了，侧边栏里没有入口
+
+这条迁移把它们补上。`fba init` 建的新库不会执行它（init 末尾的 `alembic stamp head`
+把它标成已应用而不运行），所以不会插两遍 —— 新库的行来自种子 SQL，老库的行来自这里。
+
+机制与三条纪律见 `backend/utils/data_migration.py` 的模块注释。
+"""
+
+from alembic import op
+
+from backend.plugin.core import check_plugin_installed
+from backend.utils.data_migration import (
+    DATA_MIGRATION_PK_BASE,
+    add_menu,
+    delete_by_key,
+    grant_menu,
+    scalar,
+    seeded_pk_mode,
+)
+
+# revision identifiers, used by Alembic.
+revision = '33ffb491b69f'
+down_revision = '9609aedfaf8d'
+branch_labels = None
+depends_on = None
+
+
+#: RBAC 权限锚点（`5c1d594`）。ID 照抄种子文件 —— 三个方言的 `sys_menu` 是同一套 ID。
+#: 父级按 `name` 解析，所以不用管各环境的 ID 差异。
+_PERM_ANCHORS = [
+    # (menu_id, name, perms, parent_name, sort)
+    (2049629108253622336, 'QuerySysRole', 'sys:role:list', 'SysRole', 4),
+    (2049629108253622337, 'QuerySysDept', 'sys:dept:list', 'SysDept', 2),
+    (2049629108253622338, 'QuerySysDataScope', 'data:scope:list', 'SysDataPermission', 5),
+]
+
+#: 消息中心（`#81` 的 `plugin/notification/sql/*/init_snowflake.sql`）
+_NOTIFICATION_MENU_ID = 2049629108262010880
+_NOTIFICATION_SEND_MENU_ID = 2049629108262010881
+
+#: 演示角色 —— 种子里这四个都挂了消息中心。按 `code` 解析，各环境 ID 不同也没关系。
+_DEMO_ROLE_CODES = ['STAFF', 'MANAGER', 'FINANCE_STAFF', 'VIEWER']
+
+
+def upgrade() -> None:
+    if not seeded_pk_mode():
+        # 自增主键模式下没有基础种子，也就没有「种子没同步」这个问题
+        return
+
+    conn = op.get_bind()
+
+    # ── 1. RBAC 权限锚点（5c1d594）────────────────────────────────────────────
+    for menu_id, name, perms, parent_name, sort in _PERM_ANCHORS:
+        add_menu(conn, menu_id=menu_id, name=name, title='查询', perms=perms, parent_name=parent_name, sort=sort)
+
+    # MANAGER 要能看部门树。`sys:user:list` 那条种子里早就授权过了，这里只补部门这条。
+    grant_menu(conn, row_id=DATA_MIGRATION_PK_BASE + 1, role_code='MANAGER', menu_name='QuerySysDept')
+
+    # ── 2. 消息中心（#81）─────────────────────────────────────────────────────
+    #
+    # ⚠️ 用 `check_plugin_installed` 而不是「`sys_notification` 表在不在」：那张表由
+    # 迁移 `9609aedfaf8d` 无条件创建，插件卸载了它照样在 —— 拿它当判据会给一个
+    # 已卸载的插件插菜单，而侧边栏点进去是 404。
+    if check_plugin_installed('notification'):
+        add_menu(
+            conn,
+            menu_id=_NOTIFICATION_MENU_ID,
+            name='Notification',
+            title='消息中心',
+            path='/notification',
+            icon='mdi:bell-outline',
+            menu_type=1,
+            sort=7,
+            display=1,
+        )
+        add_menu(
+            conn,
+            menu_id=_NOTIFICATION_SEND_MENU_ID,
+            name='SendNotification',
+            title='发送通知',
+            perms='sys:notification:send',
+            parent_name='Notification',
+        )
+        for offset, code in enumerate(_DEMO_ROLE_CODES, start=11):
+            grant_menu(conn, row_id=DATA_MIGRATION_PK_BASE + offset, role_code=code, menu_name='Notification')
+
+    # ⚠️ 刻意**不**补 `sys_notification` 那三条演示通知：它们是纯装饰，而其中一条的
+    # `recipient_id` 指向 sqlserver 种子里那个 admin 的 ID，搬到别的方言上是个悬空引用。
+    # 缺菜单会让整个功能没有入口（真问题），缺演示数据不会。
+
+
+def downgrade() -> None:
+    if not seeded_pk_mode():
+        return
+
+    conn = op.get_bind()
+
+    # 先删授权行再删菜单 —— 反过来的话 `grant_menu` 解析不到菜单，授权行会留成悬空
+    for code in _DEMO_ROLE_CODES:
+        role_id = scalar(conn, 'sys_role', 'id', code=code)
+        menu_id = scalar(conn, 'sys_menu', 'id', name='Notification')
+        if role_id is not None and menu_id is not None:
+            delete_by_key(conn, 'sys_role_menu', role_id=role_id, menu_id=menu_id)
+
+    manager_id = scalar(conn, 'sys_role', 'id', code='MANAGER')
+    dept_query_id = scalar(conn, 'sys_menu', 'id', name='QuerySysDept')
+    if manager_id is not None and dept_query_id is not None:
+        delete_by_key(conn, 'sys_role_menu', role_id=manager_id, menu_id=dept_query_id)
+
+    for name in ('SendNotification', 'Notification'):
+        delete_by_key(conn, 'sys_menu', name=name)
+    for _, name, _, _, _ in _PERM_ANCHORS:
+        delete_by_key(conn, 'sys_menu', name=name)

--- a/apps/api/backend/app/task/tests/test_migrations.py
+++ b/apps/api/backend/app/task/tests/test_migrations.py
@@ -265,3 +265,29 @@ def test_created_tables_declare_snowflake_pk_as_non_autoincrement() -> None:
         '这些迁移建表时没给雪花主键写 autoincrement=False，SQL Server 上会建成 IDENTITY，\n'
         '那张表在「用迁移建出来的库」（= 生产）里一行都插不进去：\n' + '\n'.join(f'  - {o}' for o in offenders)
     )
+
+
+def test_seed_files_have_a_matching_data_migration_decision() -> None:
+    """🔴 种子文件改了，就必须对「已存在的库怎么追上」做一次决定（issue #86）
+
+    种子 SQL 只在 `fba init`（从零建库）那条路径上跑一次。改了之后
+    **新建的库会有那些行、已经在跑的库永远不会有** —— 而这件事此前没有任何东西
+    会发现：CI 全绿、合并、部署，然后生产库静静地缺着几行数据。
+
+    实际后果（两次，都是真的用户可见回归）：
+
+    - `5c1d594` 加的三条 RBAC 权限锚点菜单从没进生产库，而**校验在部署那一刻
+      就生效了** —— MANAGER 演示账号原本能看的部门树当场 403
+    - `256beae` 加的「每日问候」调度同理：功能部署了，从来没跑过
+
+    这条守卫本身**证明不了**「那条 data migration 真的插了同样的行」，它只强迫作者
+    看一眼并做决定 —— 和 `test_every_crud_class_declares_its_data_scope_stance`
+    同一个物种：「忘了想这件事」会红，而不是「想错了」会红。
+
+    ⚠️ 它也覆盖插件的 `sql/`：`#81` 的消息中心菜单就是从插件那份漏掉的，
+    机制和漏法与基础种子完全一样。
+    """
+    from backend.scripts.seed_manifest import HINT, check
+
+    problems = check()
+    assert not problems, '\n'.join(problems) + HINT

--- a/apps/api/backend/scripts/seed_manifest.py
+++ b/apps/api/backend/scripts/seed_manifest.py
@@ -1,0 +1,130 @@
+"""种子文件指纹清单：把「改了种子」变成一件机器看得见的事（issue #86）。
+
+## 它守什么
+
+种子 SQL 只在 `fba init`（从零建库）那条路径上跑一次。改了种子文件之后，
+**新建的库会有那些行、已经在跑的库永远不会有** —— 而这件事此前没有任何东西会发现：
+CI 全绿、合并、部署，然后生产库静静地缺着几行数据。`5c1d594` 和 `256beae` 都是这么漏的。
+
+真正的修法是给那批新增行补一条幂等的 data migration（见
+`backend/utils/data_migration.py`）。但「记得补」这件事本身需要有人提醒 ——
+这份清单就是那个提醒：种子文件的 sha256 变了而清单没更新，测试就红。
+
+## 它**不**守什么
+
+它证明不了「那条 data migration 真的插了同样的行」，只能强迫作者**看一眼**并做决定。
+和 `test_every_crud_class_declares_its_data_scope_stance` 是同一个物种：
+「忘了想这件事」会红，而不是「想错了」会红。
+
+## 用法
+
+```bash
+pnpm --filter api seed:manifest          # 校验（CI 与 pytest 走这条）
+pnpm --filter api seed:manifest --write  # 确认过之后更新清单
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+
+from pathlib import Path
+
+BASE_PATH = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = BASE_PATH / 'sql' / 'seed_manifest.json'
+
+#: 被纳管的种子文件。两类都要 —— 插件的 `sql/` 和基础 `sql/` 是同一个机制、
+#: 同一个漏法（`#81` 的消息中心菜单就是从插件那份漏掉的）。
+_PATTERNS = (
+    ('sql', 'init_*.sql'),
+    ('plugin', 'sql/**/init_*.sql'),
+)
+
+
+def seed_files() -> list[Path]:
+    """所有纳管的种子文件，按仓库相对路径排序"""
+    found: set[Path] = set()
+    for subdir, pattern in _PATTERNS:
+        found.update(p for p in (BASE_PATH / subdir).glob(f'**/{pattern}') if p.is_file())
+    # destroy 脚本不算种子：它只在卸载插件时跑，不存在「已存在的库要追上」的问题
+    return sorted(p for p in found if 'destroy' not in p.name)
+
+
+def fingerprints() -> dict[str, str]:
+    return {p.relative_to(BASE_PATH).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest() for p in seed_files()}
+
+
+def load_manifest() -> dict[str, str]:
+    if not MANIFEST_PATH.exists():
+        return {}
+    return json.loads(MANIFEST_PATH.read_text(encoding='utf-8'))
+
+
+def write_manifest() -> None:
+    MANIFEST_PATH.write_text(
+        json.dumps(fingerprints(), ensure_ascii=False, indent=2, sort_keys=True) + '\n',
+        encoding='utf-8',
+    )
+
+
+def diff() -> tuple[list[str], list[str], list[str]]:
+    """返回 (改了的, 新增的, 删掉的)"""
+    actual, expected = fingerprints(), load_manifest()
+    changed = sorted(k for k in actual.keys() & expected.keys() if actual[k] != expected[k])
+    added = sorted(actual.keys() - expected.keys())
+    removed = sorted(expected.keys() - actual.keys())
+    return changed, added, removed
+
+
+HINT = """
+🔴 种子文件改了，但清单没更新 —— 这意味着**已经在跑的库（尤其是生产）不会有这些行**。
+种子 SQL 只在 `fba init` 从零建库时执行一次，之后再也不会重跑。
+
+两条路选一条：
+
+  1) 这次改动**新增/修改了数据行** → 补一条幂等的 data migration，让已存在的库也追上。
+     照 `backend/alembic/versions/*33ffb491b69f*.py` 的形状写，helper 在
+     `backend/utils/data_migration.py`（外键按业务键解析，别硬编码 ID）。
+  2) 这次改动**对已存在的库无影响**（只改注释、只改新库才用到的行、只是重排格式）
+     → 不用补迁移。
+
+然后跑 `pnpm --filter api seed:manifest --write` 更新清单。
+"""
+
+
+def check() -> list[str]:
+    """返回问题描述列表，空列表 = 通过"""
+    changed, added, removed = diff()
+    problems = []
+    if changed:
+        problems.append(f'内容变了：{changed}')
+    if added:
+        problems.append(f'新增的种子文件（清单里没有）：{added}')
+    if removed:
+        problems.append(f'清单里有但文件已不存在：{removed}')
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--write', action='store_true', help='更新清单（确认过之后再用）')
+    args = parser.parse_args()
+
+    if args.write:
+        write_manifest()
+        print(f'已更新 {MANIFEST_PATH.relative_to(BASE_PATH.parent)}（{len(fingerprints())} 个种子文件）')
+        return 0
+
+    problems = check()
+    if not problems:
+        print(f'种子清单一致（{len(fingerprints())} 个文件）')
+        return 0
+    print('\n'.join(problems) + HINT, file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/apps/api/backend/sql/seed_manifest.json
+++ b/apps/api/backend/sql/seed_manifest.json
@@ -1,0 +1,20 @@
+{
+  "plugin/config/sql/mysql/init_snowflake.sql": "af17278ba23fe0eab7b71791d81faadeac8609763d0210d85cd381f65c0c7413",
+  "plugin/config/sql/postgresql/init_snowflake.sql": "be726abcf69a61006ef5f6967c1e577158364cbb03752cfb3594eb6f50afc6ab",
+  "plugin/config/sql/sqlserver/init_snowflake.sql": "89ef0315663aa74c5b81cef50248acada3ce3365a580785c03cf96e108de0cf4",
+  "plugin/dict/sql/mysql/init_snowflake.sql": "30117e3057accacdeaa5e17d99cad14a9617acad32318365847749ec7bfc1e38",
+  "plugin/dict/sql/postgresql/init_snowflake.sql": "30117e3057accacdeaa5e17d99cad14a9617acad32318365847749ec7bfc1e38",
+  "plugin/dict/sql/sqlserver/init_snowflake.sql": "915898f37fbadf4df027d7131bf461eb3c43693db1d717b09a5e6f5fadc75f2a",
+  "plugin/notice/sql/mysql/init_snowflake.sql": "1fef06334a7413a777d854f4e09f150d45468a5dc1e9eaebaceb0e7dd4094762",
+  "plugin/notice/sql/postgresql/init_snowflake.sql": "1fef06334a7413a777d854f4e09f150d45468a5dc1e9eaebaceb0e7dd4094762",
+  "plugin/notice/sql/sqlserver/init_snowflake.sql": "655695125fc193e55604d40dd17467d005944878b798771a33a0afaa754fc9f6",
+  "plugin/notification/sql/mysql/init_snowflake.sql": "473e47395c74e4a578c0770bb72b4567964b8d0a94e3d3e403f781c4558b4c79",
+  "plugin/notification/sql/postgresql/init_snowflake.sql": "42a250067aa22281ddaaceb683f1e7d5efa2fabe23f03a9c2b79771624dfefd6",
+  "plugin/notification/sql/sqlserver/init_snowflake.sql": "32e7287a0e34cf6a9517e048127ea1a674c12a55e254922194f43f4506c97e3b",
+  "plugin/oauth2/sql/mysql/init_snowflake.sql": "4a45092ccf992ea92250053a80b931b787924ba61648f420555511b84f10ab6c",
+  "plugin/oauth2/sql/postgresql/init_snowflake.sql": "4a45092ccf992ea92250053a80b931b787924ba61648f420555511b84f10ab6c",
+  "plugin/oauth2/sql/sqlserver/init_snowflake.sql": "b4e0497804e46e0a0b0b8c31975b062152d551bac49c3c2e80932567b4085dcd",
+  "sql/mysql/init_snowflake_test_data.sql": "e8f55d7d621adef5345bb6d39883c47af8a61cf9eff1043c7e8e02659f472c97",
+  "sql/postgresql/init_snowflake_test_data.sql": "e4304d7f771af829dc4fa3cc32cf34753dfc0890488664dc01890426080d2e39",
+  "sql/sqlserver/init_snowflake_test_data.sql": "ecc0354dccdf7870c28d12ad74da7fe48bcee82c85d1151e4810039abea193dc"
+}

--- a/apps/api/backend/utils/data_migration.py
+++ b/apps/api/backend/utils/data_migration.py
@@ -1,0 +1,179 @@
+"""种子数据的**追加**机制：给已经在跑的库补上后来新增的那些行。
+
+## 为什么需要这一层（issue #86）
+
+schema 改动和种子数据走的是两条完全不同的路径：
+
+- **schema**：部署时 `alembic upgrade head`，已存在的库会跟上；而且
+  `test_model_matches_migrations` 兜着「改了模型忘了生成迁移」
+- **种子数据**：只有 `fba init`（`drop_all` + `create_all` + 灌种子 + `stamp head`）
+  会执行。已存在的库 🔴 **不会**跟上 —— 没有版本号、没有「这批种子进过这个库吗」
+  的记录，也没有任何检查会发现「种子文件改了但某个库没跟上」
+
+实际后果（不是理论风险）：`5c1d594` 往种子里加了三条 RBAC 权限锚点菜单，代码
+部署那一刻校验就生效了，而菜单从来没进生产库 —— MANAGER 演示账号原本能看的
+部门树当场 403。`256beae` 加的「每日问候」调度同理：功能部署了，从来没跑过。
+
+## 机制：就用 alembic，不另造一套
+
+数据迁移就是一条**普通的 alembic revision**，只是 `upgrade()` 里不是 DDL 而是
+幂等的 INSERT。这样白拿三样东西：`alembic_version` 天然记录了「这个库跑到哪了」、
+部署流程已经在跑 `alembic upgrade head`、`fba init` 之后的 `stamp head` 会把它标成
+已应用而**不执行**（新库的行本来就来自种子 SQL，不会插两遍）。
+
+## 三条纪律
+
+- 🔴 **外键一律按业务键解析，不要硬编码 ID。** 三个方言的种子各有一套 ID
+  （postgresql 的角色在 `4000000000000000xxx` 区间、另两个在 `3000000000000000xxx`），
+  而生产库的 ID 又只在生产库里成立。用 `sys_menu.name` / `sys_role.code` 这类
+  跨环境稳定的键去查，写一次三个方言都对。
+- 🔴 **幂等靠业务键判存在，不要靠吃唯一约束冲突。** 三种方言的冲突语法各不相同
+  （`MERGE` / `ON CONFLICT` / `INSERT IGNORE`），写任一种都会在另外两种上炸。
+- ⚠️ **不要重新灌整份种子。** 那会把别人在界面上改过的数据覆盖回去。
+  只补「按业务键查不到」的那些行。
+"""
+
+from typing import Any
+
+import sqlalchemy as sa
+
+from sqlalchemy.engine import Connection
+
+from backend.common.enums import PrimaryKeyType
+from backend.core.conf import settings
+from backend.utils.timezone import timezone
+
+#: 数据迁移专用的主键区间。**种子文件不要用这一段。**
+#:
+#: 只用在「纯连接行」上（`sys_role_menu` 这类只有代理主键、没人引用它的表）。
+#: 有语义的行（菜单）一律**照抄种子里那个 ID** —— 三个方言的 `sys_menu` 用的是
+#: 同一套 ID，抄过来能让「升级上来的库」和「`fba init` 新建的库」结构与数据都收敛，
+#: 排障时不用先问一句「这个库是哪条路建出来的」。
+DATA_MIGRATION_PK_BASE = 5000000000000000000
+
+
+def _lightweight_table(name: str, columns: set[str]) -> sa.TableClause:
+    """按需拼一个只有列名的表引用
+
+    刻意**不**去 import 真正的 ORM 模型：迁移要在「当时那个 schema」上执行，
+    而模型是「现在这个 schema」。一条老迁移 import 模型，等模型加了新列之后
+    它就会往一个当时还没有那一列的表里插数据 —— 这是数据迁移最经典的坑。
+    """
+    return sa.table(name, *[sa.column(c) for c in sorted(columns)])
+
+
+def seeded_pk_mode() -> bool:
+    """当前主键模式下，种子数据这条路径存不存在
+
+    🔴 数据迁移里**不要调 `snowflake.generate()`**：它要么读环境变量、要么去 Redis
+    抢节点号（`snowflake.init()`），而 `alembic upgrade` 是部署时一个独立的
+    `migrate` 容器，把 Redis 拉成它的前置依赖是个新耦合，而且失败时报的是
+    「雪花 ID 生成失败」——完全看不出跟数据迁移有关。
+    所以主键一律用显式常量（见 `DATA_MIGRATION_PK_BASE` 的注释）。
+
+    代价是自增主键模式下这些常量不能用（mssql 会报
+    `Cannot insert explicit value for identity column`）。但那个模式**本来就没有
+    基础种子**：`build_sql_filename()` 只在雪花模式下拼出 `init_snowflake_test_data.sql`，
+    自增模式找的是一个不存在的 `init_test_data.sql`。没有种子就没有「种子没同步」
+    这个问题，整条数据迁移直接跳过即可。
+    """
+    return PrimaryKeyType(settings.DATABASE_PK_MODE) == PrimaryKeyType.snowflake
+
+
+def scalar(conn: Connection, table: str, column: str, **where: Any) -> Any | None:
+    """按业务键查一个标量（典型用途：拿 `sys_menu.name` 换它的 id）"""
+    t = _lightweight_table(table, {column, *where})
+    stmt = sa.select(t.c[column]).where(*[t.c[k] == v for k, v in where.items()]).limit(1)
+    return conn.execute(stmt).scalar()
+
+
+def insert_if_absent(conn: Connection, table: str, key: dict[str, Any], values: dict[str, Any]) -> bool:
+    """`key` 查不到时插入一行，返回是否真的插了
+
+    :param conn: `op.get_bind()`
+    :param table: 表名
+    :param key: 判存在用的业务键（也会一起写进新行）
+    :param values: 其余列
+    :return: True = 插了新行；False = 已经有了，什么都没做
+    """
+    t = _lightweight_table(table, {*key, *values})
+    exists = conn.execute(
+        sa.select(sa.literal(1)).select_from(t).where(*[t.c[k] == v for k, v in key.items()]).limit(1)
+    ).first()
+    if exists is not None:
+        return False
+    conn.execute(sa.insert(t).values({**key, **values}))
+    return True
+
+
+def delete_by_key(conn: Connection, table: str, **key: Any) -> int:
+    """按业务键删除（给 `downgrade()` 用）"""
+    t = _lightweight_table(table, set(key))
+    result = conn.execute(sa.delete(t).where(*[t.c[k] == v for k, v in key.items()]))
+    return result.rowcount or 0
+
+
+def add_menu(
+    conn: Connection,
+    *,
+    menu_id: int,
+    name: str,
+    title: str,
+    parent_name: str | None = None,
+    path: str | None = None,
+    perms: str | None = None,
+    icon: str | None = None,
+    menu_type: int = 2,
+    sort: int = 0,
+    display: int = 0,
+) -> bool:
+    """补一条 `sys_menu`，父级按 `name` 解析
+
+    幂等判定和父级解析都用 `name`：它是这张表里唯一跨环境稳定的键
+    （`title` 管理员随时能改、`id` 在别的表里每套环境不同）。
+
+    ⚠️ `menu_id` 要**照抄种子文件里那个值** —— `sys_menu` 的 ID 三个方言是同一套，
+    抄过来才能让升级上来的库和新建的库收敛。
+
+    :return: True = 插了；False = 已经有了 / 父级不存在
+    """
+    parent_id = None
+    if parent_name is not None:
+        parent_id = scalar(conn, 'sys_menu', 'id', name=parent_name)
+        if parent_id is None:
+            # 父级不在（比如那个模块被删了 / 这个库的种子更老）——跳过而不是插一条孤儿。
+            # `traversal_to_tree` 会把孤儿提到根，表现是侧边栏凭空多出一条顶层菜单。
+            return False
+
+    values: dict[str, Any] = {
+        'id': menu_id,
+        'title': title,
+        'path': path,
+        'sort': sort,
+        'icon': icon,
+        'type': menu_type,
+        'perms': perms,
+        'status': 1,
+        'display': display,
+        'link': '',
+        'remark': None,
+        'parent_id': parent_id,
+        'created_time': timezone.now(),
+    }
+    return insert_if_absent(conn, 'sys_menu', {'name': name}, values)
+
+
+def grant_menu(conn: Connection, *, row_id: int, role_code: str, menu_name: str) -> bool:
+    """把一条菜单授权给一个角色（`sys_role_menu`），角色和菜单都按业务键解析
+
+    `sys_role_menu` 是纯连接行、主键没人引用，所以 `row_id` 用
+    `DATA_MIGRATION_PK_BASE` 那一段，不必和种子里的值一致。
+
+    :return: True = 插了；False = 角色/菜单不存在，或者已经授权过
+    """
+    role_id = scalar(conn, 'sys_role', 'id', code=role_code)
+    menu_id = scalar(conn, 'sys_menu', 'id', name=menu_name)
+    if role_id is None or menu_id is None:
+        return False
+
+    return insert_if_absent(conn, 'sys_role_menu', {'role_id': role_id, 'menu_id': menu_id}, {'id': row_id})

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "db:history": "cd backend && uv run --no-sync alembic history",
     "e2e:server": "ENV_FILE=.env.e2e uv run --no-sync python -m uvicorn backend.main:app --port 8001",
     "celery:worker": "CELERY_CUSTOM_WORKER_POOL=celery_aio_pool.pool:AsyncIOPool uv run --no-sync celery -A backend.app.task.celery worker -l info --pool=custom",
-    "celery:beat": "uv run --no-sync celery -A backend.app.task.celery beat -l info"
+    "celery:beat": "uv run --no-sync celery -A backend.app.task.celery beat -l info",
+    "seed:manifest": "uv run --no-sync python -m backend.scripts.seed_manifest"
   }
 }


### PR DESCRIPTION
Closes #86

## 问题

schema 走 alembic（部署时 `upgrade head`，还有 `test_model_matches_migrations` 兜着）；种子数据只在 `fba init` 从零建库时跑一次。**已经在跑的库再也不会重新执行那份 SQL**，没有版本号、没有记录、没有任何检查。

漏过两次，两次都是真的用户可见回归：

| 提交 | 代码 | 数据 |
|---|---|---|
| `5c1d594` | RBAC 校验部署即生效 | 三条权限锚点菜单从没进生产库 → **MANAGER 演示账号的部门树当场 403** |
| `#81` | 消息中心功能上线 | 菜单没进 → **侧边栏里没有入口** |

## 机制：就用 alembic，不另造一套

数据迁移 = 一条普通 revision，`upgrade()` 里是幂等 INSERT 而不是 DDL。白拿三样：`alembic_version` 天然记录每个库跑到哪、部署已经在跑 `upgrade head`、`fba init` 末尾的 `stamp head` 会把它标成已应用而**不执行**（新库的行来自种子 SQL，不会插两遍）。

helper 在 `backend/utils/data_migration.py`，三条纪律：

- 外键按业务键解析（`sys_menu.name` / `sys_role.code`），**不硬编码 ID** —— 三个方言的种子各有一套 ID，生产库的又只在生产库里成立
- 幂等靠业务键判存在，**不吃唯一约束冲突** —— 三种方言的冲突语法各不相同，写任一种都会在另外两种上炸
- 🔴 **不调 `snowflake.generate()`** —— 它要读环境变量或去 Redis 抢节点号，而 `alembic upgrade` 是部署时一个独立的 migrate 容器，把 Redis 变成它的前置依赖是个新耦合，失败时还报「雪花 ID 生成失败」。有语义的行照抄种子里那个 ID（三个方言的 `sys_menu` 是同一套，抄过来能让「升级上来的库」和「新建的库」**收敛**），纯连接行用 `DATA_MIGRATION_PK_BASE` 那一段

## 守卫

`test_seed_files_have_a_matching_data_migration_decision`：种子文件 sha256 变了而 `seed_manifest.json` 没更新就红，文案里给「补迁移」和「确认无影响」两条路。

它**证明不了**那条迁移真的插了同样的行，只强迫作者看一眼并做决定——和 `test_every_crud_class_declares_its_data_scope_stance` 同一个物种。清单覆盖**插件的 `sql/` 也算**（`#81` 就是从插件那份漏掉的）。

## 验证（不是只跑一遍 upgrade）

在已经有那些行的库上 upgrade 是个 no-op，证明不了任何事。所以：

1. 把开发库和 `fba_test` 的那几行**删掉**，造出「老库」
2. 真正的 `pnpm db:upgrade`（不是手搓的 `op` 壳）→ 3 条锚点 + 2 条消息中心菜单 + 5 条授权行全部补上；`QuerySysDept` 的 id **等于种子里那个值**（收敛），父级按 `name` 解析正确
3. 再跑一遍 → 计数不变（幂等）
4. `downgrade` → 清空；再 `upgrade` → 回来
5. 守卫做过**变异**：往任一种子文件追加一行 → 退出码 1 并打出修法

pytest **232 passed**（+1）。

## 一处刻意没做

`sys_notification` 那三条演示通知没补：纯装饰，且其中一条的 `recipient_id` 指向 sqlserver 种子里那个 admin 的 ID，搬到别的方言上是悬空引用。缺菜单会让功能没有入口（真问题），缺演示数据不会。

## 留给 #83

「每日问候」调度（`256beae`）的种子改动属于 PR #83，按新约定该由它自己补一条数据迁移——那正好是这个机制的第一次实战。合了这条之后 #83 的守卫会红，提醒它补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
