### PR TITLE
test(ci): 给 PostgreSQL 补一条平行的 pytest job，顺手修掉三个只在它上面才现形的 bug (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           --health-start-period 20s
 
       redis:
-        image: redis:7-alpine
+        image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
         # 6380 是为了和 .env.example / docker-compose.dev.yml 对齐。
         # 改端口要同步改那两处，否则表现是 Redis 连不上而不是端口问题
         ports:
@@ -218,6 +218,123 @@ jobs:
         working-directory: apps/api
         run: uv run --no-sync pytest
 
+  # PostgreSQL 的平行 job（issue #5）。
+  #
+  # 🔴 **主线仍然是 SQL Server，这个 job 是第二条腿，不是取代。** 结构刻意和上面
+  # `test-backend` 保持一一对应，改一个记得看另一个。
+  #
+  # 为什么值得多花这几分钟：postgres 路径此前**零自动化覆盖**——唯一一次验证是
+  # 2026-08-25 那次人工部署（腾讯云那台内存装不下 SQL Server），当场炸出两个 bug。
+  # 补这个 job 的时候第一次在 postgres 上跑 pytest，又当场炸出三个，全部是
+  # 「代码分支存在、但从没被任何自动化跑过」：
+  #   1. 五处测试用 `url.replace('/fba?', '/fba_test?')` 换库名，而只有 mssql 的
+  #      结果后端 URL 带查询串 —— postgres/mysql 上替换**静默失效**，测试连到开发库
+  #   2. `test_fresh_install_has_every_index_the_models_declare` 直接查 `sys.indexes`
+  #      （SQL Server 专属系统目录表）
+  #   3. `c0000000comments` 用裸 `contextlib.suppress` 容错，而 postgres 里一条语句
+  #      失败会毒化整个事务，Python 层吞掉异常救不回来
+  # 三条都不是「postgres 支持得不好」，是「没人跑过」。
+  #
+  # 这个 job 比 test-backend 快得多：不用装 ODBC 驱动，postgres 容器几秒就绪。
+  test-backend-postgres:
+    name: pytest · PostgreSQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      DATABASE_TYPE: postgresql
+      DATABASE_HOST: 127.0.0.1
+      DATABASE_PORT: "5432"
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres
+      DATABASE_SCHEMA: fba
+      # 🔴 和 sqlserver 同理：postgres 也只有 init_snowflake_test_data.sql 这一份种子，
+      # 改成 autoincrement 会静默跳过灌数据，库建好了却没有 admin
+      DATABASE_PK_MODE: snowflake
+      REDIS_HOST: 127.0.0.1
+      REDIS_PORT: "6380"
+      TOKEN_SECRET_KEY: ci-only-not-a-real-secret-Ku3Jd9wQpZ2vLxR7
+      PLUGIN_PIP_CHINA: "false"
+
+    services:
+      postgres:
+        # 钉 digest 的理由同 mssql（issue #66）：浮动标签会让 CI 在没人改代码的
+        # 情况下变红/变绿。升级时显式换这串，不要删掉它让标签重新浮动。
+        image: postgres:16-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+
+      redis:
+        image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
+        ports:
+          - 6380:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: apps/api/uv.lock
+
+      - name: uv sync
+        working-directory: apps/api
+        run: uv sync --locked --no-group lint
+
+      - name: .env
+        working-directory: apps/api
+        run: cp backend/.env.example backend/.env
+
+      # fba 建成空库即可（理由同 test-backend）；fba_test 是测试库；
+      # fba_empty 给下面那条容错分支的守卫用
+      - name: 建库（fba + fba_test + fba_empty）
+        env:
+          PG_CID: ${{ job.services.postgres.id }}
+        run: |
+          for db in fba fba_test fba_empty; do
+            docker exec "$PG_CID" psql -U postgres -c "CREATE DATABASE $db;"
+          done
+
+      - name: 重建测试库
+        working-directory: apps/api
+        run: uv run --no-sync python -m backend.scripts.reset_test_db
+
+      # 顺序不能调，理由同 test-backend
+      - name: 测试库升到 head
+        working-directory: apps/api/backend
+        env:
+          DATABASE_SCHEMA: fba_test
+        run: uv run --no-sync alembic upgrade head
+
+      # 🔴 这一步守的是 `c0000000comments` 里那个「容错」分支 —— 它是整条迁移链上
+      # 唯一会**故意让语句失败再吞掉**的地方，而各方言在「失败之后事务还能不能用」
+      # 上语义相反（详见那份迁移的 `_tolerate_already_applied()`）。
+      # 空库上跑它，8 条 ALTER 全部命中不存在的表，正好把容错分支整条走一遍：
+      # 退回裸 suppress 的话，postgres 这里会连环 InFailedSQLTransactionError。
+      # 平时这个分支在 CI 里一次都不会执行（测试库是 create_all + stamp head 的）。
+      - name: 迁移的容错分支（空库）
+        working-directory: apps/api/backend
+        env:
+          DATABASE_SCHEMA: fba_empty
+        run: uv run --no-sync alembic upgrade c0000000comments
+
+      - name: pytest
+        working-directory: apps/api
+        run: uv run --no-sync pytest
+
   test-e2e:
     name: playwright · E2E
     runs-on: ubuntu-latest
@@ -259,7 +376,7 @@ jobs:
           --health-start-period 20s
 
       redis:
-        image: redis:7-alpine
+        image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
         ports:
           - 6380:6379
         options: >-

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -173,6 +173,44 @@ refresh token 的 JWT 里同样带着 `sub` 和 `session_uuid`（`create_refresh
   不再暴露 `db:init:auto` 别名，避免和 reset 形成重复入口。不要把 alembic downgrade base && upgrade head 当成重置：空基线的 downgrade
   不会删表或业务数据，它只适合验证迁移链。
 
+### 🔴 迁移里「失败了就吞掉」的写法，三种方言语义**相反**（issue #5）
+
+「补齐历史遗留」类的迁移常写成「执行，失败就忽略」（新库天然已是目标状态，
+再执行会报 already exists）。这个写法的正确形态**取决于方言**：
+
+| 方言 | 一条 DDL 失败之后 | 裸 `contextlib.suppress` | `begin_nested()`（SAVEPOINT） |
+|---|---|---|---|
+| postgresql | 整个事务被置成 aborted | ❌ 后续语句连环 `InFailedSQLTransactionError` | ✅ |
+| mssql | 事务照常可用 | ✅ | ❌ `Cannot roll back sa_savepoint_1...` |
+
+两条都是实测出来的（空库 `alembic upgrade c0000000comments`，8 条 ALTER 全部
+命中不存在的表）。postgres 那条的要害是：**Python 层把异常吞掉，并不能让已经
+作废的事务活过来**——报错信息完全不提「事务」，只说下一条语句失败了。
+
+`c0000000comments` 里的 `_tolerate_already_applied()` 是现成的抄法：postgres 走
+SAVEPOINT、其余走 suppress、离线 `--sql` 模式直接放行（那时 bind 是
+`MockConnection`，没有 `begin_nested()`，不放行会打掉
+`test_migrations_compile_offline_for_every_supported_dialect` 那条守卫）。
+
+⚠️ **不要拿一种方言的实测结论当通用前提。** 这条迁移原来的 docstring 写着
+「实测 SQL Server 在这里不会毒化事务」——对 mssql 成立，对 postgres 不成立，
+而当时只有 SQL Server 在 CI 里跑，所以这句话一直看着是对的。
+
+### ⚠️ 整条迁移链**不能**从 base 重放，这是设计而不是缺陷
+
+有人（包括 issue #5 一开始）会想加一条「空库 `alembic upgrade head` 必须成功」
+的冒烟检查。跑不通，而且不该跑通：
+
+- 基线 `b0000000baseline` **刻意是空的**（只是起点标记，不含建表 DDL）
+- 所以空库升上去时，`c0000000comments` 的 ALTER 全部落空（现在被容错分支接住），
+  再往后 `33ffb491b69f` 要往 `sys_role`/`sys_menu` 插种子行 —— 那些表不存在，炸
+- 反过来，先 `create_all` 再 stamp 基线也不行：`9609aedfaf8d` 会 `CREATE TABLE
+  sys_notification`，而 `create_all` 已经建过了
+
+**新库的正路是 `fba init`（create_all + 种子 + stamp head），不是重放迁移。**
+迁移链只对「基线之后才出现的增量」负责。真正需要守的是「下一条迁移在三种方言上
+都能编译」，那条守卫已经有了（`test_migrations_compile_offline_for_every_supported_dialect`）。
+
 ### 🔴 alembic 引进来**之前**手写 ALTER 加的列，守卫测试抓不到
 
 `test_model_matches_migrations` 比对的是**模型 vs fba_test**。如果一列是手写
@@ -706,6 +744,33 @@ docker exec fba_mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$PW" 
   代价是要先跑过一次 `uv sync --group dev`
 - **`turbo.json` 里 `test` 必须 `cache: false`** —— 测试打真实数据库，
   缓存住「上次通过了」毫无意义
+
+### 🔴 pytest 现在在**两种方言**上跑，别再假设只有 SQL Server（issue #5）
+
+CI 有两个平行 job：`pytest · SQL Server`（主线）和 `pytest · PostgreSQL`。
+补上后者的时候，第一次在 postgres 上跑 pytest 当场炸出三个「代码分支存在、
+但从没被任何自动化跑过」的 bug。写测试时碰到这三样先问一句「换个方言还成立吗」：
+
+| 要干的事 | ❌ 别这么写 | ✅ 这么写 |
+|---|---|---|
+| 把 URL 里的库名换成测试库 | `url.replace(f'/{SCHEMA}?', …)` | `backend/tests/utils/db.py: sync_test_db_url()` |
+| 查库上真实存在的索引 / 表 | `SELECT … FROM sys.indexes` | `sqlalchemy.inspect(engine).get_indexes(...)` |
+| 造布尔列的数据 | `0` / `1` | `true` / `false`（postgres 类型严格） |
+
+第一条那个字符串替换是最阴的：它依赖库名后面紧跟一个 `?`，而只有 SQL Server 的
+结果后端 URL 带查询串（`?driver=ODBC+Driver+18…`）。postgres/mysql 上**替换静默
+失效**，于是五处测试连的是**开发库**——往 `fba` 里塞数据、拿 `fba_test` 的结果
+断言，报错信息一个字都不提数据库连错了。
+
+本地想在 postgres 上跑一遍：
+
+```bash
+docker compose -f docker-compose.dev.yml --profile postgresql up -d postgres
+# 建 fba / fba_test 两个空库，然后带着环境变量跑（env 优先级高于 backend/.env）
+DATABASE_TYPE=postgresql DATABASE_PORT=5432 DATABASE_USER=postgres \
+  DATABASE_PASSWORD=postgres uv run python -m backend.scripts.reset_test_db
+DATABASE_TYPE=postgresql … uv run pytest
+```
 
 ### 写测试时：`UPLOAD_DIR` 必须顶到 tmp
 

--- a/apps/api/backend/alembic/versions/20260822_1831-c0000000comments_sync_column_comments.py
+++ b/apps/api/backend/alembic/versions/20260822_1831-c0000000comments_sync_column_comments.py
@@ -30,6 +30,8 @@ Create Date: 2026-08-22 18:30:43.003028+08:00
 
 import contextlib
 
+from collections.abc import Iterator
+
 import sqlalchemy as sa
 import sqlalchemy.exc
 
@@ -41,6 +43,46 @@ revision = 'c0000000comments'
 down_revision = 'b0000000baseline'
 branch_labels = None
 depends_on = None
+
+
+@contextlib.contextmanager
+def _tolerate_already_applied() -> Iterator[None]:
+    """吞掉「这一列已经是目标状态」那类失败，且只吞这一条语句。
+
+    🔴 **三种方言在「一条语句失败之后事务还能不能用」上语义是相反的，
+    这里必须分支，两边都不能照抄对方。** 实测（issue #5）：
+
+    | 方言 | 一条 DDL 失败之后 | 裸 `contextlib.suppress` | `begin_nested()`（SAVEPOINT） |
+    |---|---|---|---|
+    | postgresql | 整个事务被置成 aborted | ❌ 后续语句连环 `InFailedSQLTransactionError` | ✅ 回滚到语句之前 |
+    | mssql | 事务照常可用 | ✅ | ❌ `Cannot roll back sa_savepoint_1...`（出错时保存点已经没了） |
+
+    postgres 那一列是「Python 层把异常吞掉并不能让事务活过来」——
+    这条迁移原来只有 `suppress`，在 postgres 空库上 `upgrade head` 第一条
+    ALTER 失败之后就连环崩。mssql 那一列是反过来：出错时 SQL Server 已经把
+    保存点丢掉了，再 `ROLLBACK TO SAVEPOINT` 是第二次报错。
+
+    旧 docstring 写的「实测 SQL Server 在这里不会毒化事务」没错，
+    错在**把一种方言的实测结论当成了通用前提**。
+
+    ⚠️ 仍然只吞 `ProgrammingError`：连接断了、权限不足必须让迁移失败。
+    """
+    # 离线模式（`alembic … --sql`）下没有任何语句真的执行，也就没有「事务被毒化」
+    # 这回事；而那时 bind 是 `MockConnection`，压根没有 `begin_nested()`。
+    # 不判这一条会打掉 `test_migrations_compile_offline_for_every_supported_dialect`
+    # ——那是 issue #59 留下的守卫，正是它替这条迁移挡住方言专属对象泄漏。
+    if op.get_context().as_sql or op.get_bind().dialect.name != 'postgresql':
+        with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+            yield
+        return
+
+    nested = op.get_bind().begin_nested()
+    try:
+        yield
+    except sqlalchemy.exc.ProgrammingError:
+        nested.rollback()
+    else:
+        nested.commit()
 
 
 def _existing_types() -> dict[str, sa.types.TypeEngine]:
@@ -111,14 +153,14 @@ def upgrade() -> None:
     这不是这一份的特例 —— **凡是「补齐历史遗留」类的迁移都有这个形状**：
     新建的库天然就是目标状态。写这类迁移时先问「新库跑这一步会怎样」。
 
-    ⚠️ 只吞 `ProgrammingError`（"already exists" 属于它），不吞所有异常 ——
-    连接断了、权限不足也是异常，那些必须让迁移失败。实测 SQL Server 在这里
-    不会毒化事务，后续语句照常执行。
+    ⚠️ 每一条都套 SAVEPOINT 而不是裸 `contextlib.suppress` —— 原因见
+    `_tolerate_already_applied()`：postgres 上一条语句失败会毒化整个事务，
+    只吞 Python 异常救不回来。
     """
     t = _existing_types()
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column('sys_dept', 'code', existing_type=t['varchar32'], comment='部门编码', existing_nullable=False)
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_file',
             'path',
@@ -127,7 +169,7 @@ def upgrade() -> None:
             existing_comment='相对 UPLOAD_DIR 的存储路径',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_file',
             'is_public',
@@ -136,7 +178,7 @@ def upgrade() -> None:
             comment='是否落在公开子树（不鉴权可读）',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log',
             'request_headers',
@@ -144,11 +186,11 @@ def upgrade() -> None:
             comment='请求头（已脱敏）',
             existing_nullable=True,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log', 'response_headers', existing_type=t['longtext'], comment='响应头', existing_nullable=True
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log',
             'response_body',
@@ -156,9 +198,9 @@ def upgrade() -> None:
             comment='响应体（超限截断）',
             existing_nullable=True,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column('sys_role', 'code', existing_type=t['varchar32'], comment='角色编码', existing_nullable=False)
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_user',
             'timezone',
@@ -171,7 +213,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     t = _existing_types()
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_user',
             'timezone',
@@ -181,7 +223,7 @@ def downgrade() -> None:
             existing_comment='显示时区(IANA 标识)',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_role',
             'code',
@@ -190,7 +232,7 @@ def downgrade() -> None:
             existing_comment='角色编码',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log',
             'response_body',
@@ -199,7 +241,7 @@ def downgrade() -> None:
             existing_comment='响应体（超限截断）',
             existing_nullable=True,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log',
             'response_headers',
@@ -208,7 +250,7 @@ def downgrade() -> None:
             existing_comment='响应头',
             existing_nullable=True,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_opera_log',
             'request_headers',
@@ -217,7 +259,7 @@ def downgrade() -> None:
             existing_comment='请求头（已脱敏）',
             existing_nullable=True,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_file',
             'is_public',
@@ -227,7 +269,7 @@ def downgrade() -> None:
             existing_comment='是否落在公开子树（不鉴权可读）',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_file',
             'path',
@@ -236,7 +278,7 @@ def downgrade() -> None:
             existing_comment='相对落盘根目录的存储路径',
             existing_nullable=False,
         )
-    with contextlib.suppress(sqlalchemy.exc.ProgrammingError):
+    with _tolerate_already_applied():
         op.alter_column(
             'sys_dept',
             'code',

--- a/apps/api/backend/app/task/tests/test_prune_logs.py
+++ b/apps/api/backend/app/task/tests/test_prune_logs.py
@@ -17,8 +17,7 @@ from sqlalchemy import create_engine, delete, func, select
 from sqlalchemy.orm import sessionmaker
 
 from backend.app.admin.model import LoginLog, OperaLog
-from backend.app.task.celery import get_result_backend
-from backend.core.conf import settings
+from backend.tests.utils.db import sync_test_db_url
 from backend.utils.timezone import timezone
 
 MARK = 'pytest-prune'
@@ -30,9 +29,7 @@ _next_id = iter(range(910000000000000001, 910000000000001000))
 
 @pytest.fixture(scope='module')
 def factory():
-    url = get_result_backend().removeprefix('db+').replace(
-        f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
-    )
+    url = sync_test_db_url()
     engine = create_engine(url, pool_pre_ping=True, future=True)
     yield sessionmaker(engine, expire_on_commit=False)
     engine.dispose()
@@ -61,12 +58,21 @@ def seed_login(factory, *, days_ago: float, n: int = 1) -> None:
     now = timezone.now()
     with factory() as s:
         for i in range(n):
-            s.execute(LoginLog.__table__.insert().values(
-                id=next(_next_id),
-                user_uuid=f'{MARK}-{days_ago}-{i}', username=MARK, status=1,
-                ip='127.0.0.1', os='t', browser='t', device='t', msg='t',
-                login_time=at, created_time=now,   # ← 故意错开
-            ))
+            s.execute(
+                LoginLog.__table__.insert().values(
+                    id=next(_next_id),
+                    user_uuid=f'{MARK}-{days_ago}-{i}',
+                    username=MARK,
+                    status=1,
+                    ip='127.0.0.1',
+                    os='t',
+                    browser='t',
+                    device='t',
+                    msg='t',
+                    login_time=at,
+                    created_time=now,  # ← 故意错开
+                )
+            )
         s.commit()
 
 
@@ -75,13 +81,25 @@ def seed_opera(factory, *, days_ago: float, n: int = 1) -> None:
     now = timezone.now()
     with factory() as s:
         for i in range(n):
-            s.execute(OperaLog.__table__.insert().values(
-                id=next(_next_id),
-                trace_id=f'{MARK}-{days_ago}-{i}', username=MARK, method='GET',
-                title='t', path='/t', ip='127.0.0.1', os='t', browser='t', device='t',
-                code='200', status=1, cost_time=1.0,
-                opera_time=at, created_time=now,   # ← 故意错开
-            ))
+            s.execute(
+                OperaLog.__table__.insert().values(
+                    id=next(_next_id),
+                    trace_id=f'{MARK}-{days_ago}-{i}',
+                    username=MARK,
+                    method='GET',
+                    title='t',
+                    path='/t',
+                    ip='127.0.0.1',
+                    os='t',
+                    browser='t',
+                    device='t',
+                    code='200',
+                    status=1,
+                    cost_time=1.0,
+                    opera_time=at,
+                    created_time=now,  # ← 故意错开
+                )
+            )
         s.commit()
 
 
@@ -156,8 +174,8 @@ def test_boundary_is_strictly_older_than(db):
     差一天的实现（`<=` 还是 `<`、cutoff 算错一天）在小数据量下看不出来，
     但它决定「保留 30 天」到底是 30 天还是 29 天。
     """
-    seed_login(db, days_ago=29.9)   # 还没到 30 天
-    seed_login(db, days_ago=30.1)   # 过了
+    seed_login(db, days_ago=29.9)  # 还没到 30 天
+    seed_login(db, days_ago=30.1)  # 过了
     run_prune(days=30)
     assert count(db, LoginLog) == 1
 
@@ -220,10 +238,14 @@ def seed_result(factory, *, days_ago: float, n: int = 1) -> None:
     at = timezone.now() - timedelta(days=days_ago)
     with factory() as s:
         for i in range(n):
-            s.execute(TaskExtended.__table__.insert().values(
-                task_id=f'{MARK}-{days_ago}-{i}', status='SUCCESS',
-                name=MARK, date_done=at,
-            ))
+            s.execute(
+                TaskExtended.__table__.insert().values(
+                    task_id=f'{MARK}-{days_ago}-{i}',
+                    status='SUCCESS',
+                    name=MARK,
+                    date_done=at,
+                )
+            )
         s.commit()
 
 
@@ -231,9 +253,7 @@ def count_results(factory) -> int:
     from backend.app.task.model import TaskExtended
 
     with factory() as s:
-        return s.execute(
-            select(func.count()).select_from(TaskExtended).where(TaskExtended.name == MARK)
-        ).scalar_one()
+        return s.execute(select(func.count()).select_from(TaskExtended).where(TaskExtended.name == MARK)).scalar_one()
 
 
 @pytest.fixture

--- a/apps/api/backend/app/task/tests/test_scheduler_api.py
+++ b/apps/api/backend/app/task/tests/test_scheduler_api.py
@@ -93,7 +93,8 @@ def test_create_returns_id(client: TestClient, token_headers, created):
 def test_duplicate_name_conflicts(client: TestClient, token_headers, created, uniq):
     """重名要给业务错误，不能让库上的唯一约束抛 IntegrityError。"""
     r = client.post(
-        BASE, headers=token_headers,
+        BASE,
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_logs', 'type': 1, 'crontab': '15 3 * * *'},
     )
     assert r.status_code != 200 or r.json().get('code') != 200
@@ -107,7 +108,8 @@ def test_unregistered_task_rejected(client: TestClient, token_headers, uniq):
     「累计触发次数」照涨 —— 看起来一切正常，实际什么都没跑。
     """
     r = client.post(
-        BASE, headers=token_headers,
+        BASE,
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_log', 'type': 1, 'crontab': '* * * * *'},
     )
     assert r.status_code != 200 or r.json().get('code') != 200
@@ -121,8 +123,10 @@ def test_unregistered_task_rejected(client: TestClient, token_headers, uniq):
         ({'type': 0}, '间隔调度缺间隔字段'),
         ({'type': 1, 'crontab': '* * * * *', 'kwargs': '[1]'}, 'kwargs 不是 JSON 对象'),
         ({'type': 1, 'crontab': '* * * * *', 'args': '{"a":1}'}, 'args 不是 JSON 数组'),
-        ({'type': 1, 'crontab': '* * * * *', 'expire_seconds': 60,
-          'expire_time': '2030-01-01T00:00:00+08:00'}, '截止时间与秒数二选一'),
+        (
+            {'type': 1, 'crontab': '* * * * *', 'expire_seconds': 60, 'expire_time': '2030-01-01T00:00:00+08:00'},
+            '截止时间与秒数二选一',
+        ),
     ],
 )
 def test_invalid_schedule_rejected(client: TestClient, token_headers, uniq, payload, why):
@@ -180,7 +184,8 @@ def test_toggle_status_does_not_need_full_object(client: TestClient, token_heade
 
 def test_update_keeps_name_check(client: TestClient, token_headers, created, uniq):
     r = client.put(
-        f'{BASE}/{created}', headers=token_headers,
+        f'{BASE}/{created}',
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_logs', 'type': 1, 'crontab': '30 4 * * *'},
     )
     assert r.status_code == 200, r.text
@@ -192,7 +197,8 @@ def test_update_keeps_name_check(client: TestClient, token_headers, created, uni
 
 def test_soft_delete_hides_from_list(client: TestClient, token_headers, uniq):
     r = client.post(
-        BASE, headers=token_headers,
+        BASE,
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_logs', 'type': 1, 'crontab': '15 3 * * *'},
     )
     pk = r.json()['data']['id']
@@ -203,7 +209,8 @@ def test_soft_delete_hides_from_list(client: TestClient, token_headers, uniq):
     # 🔴 软删之后同名必须能再建：`deleted` 不是布尔而是「0 或这一行自己的 id」，
     # 唯一约束是 (name, deleted) —— 这条设计的全部意义就是让它成立
     again = client.post(
-        BASE, headers=token_headers,
+        BASE,
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_logs', 'type': 1, 'crontab': '15 3 * * *'},
     )
     assert again.status_code == 200, again.text
@@ -236,23 +243,24 @@ def test_result_fields_are_extended(client: TestClient, token_headers):
     from sqlalchemy import create_engine, delete, insert
     from sqlalchemy.orm import sessionmaker
 
-    from backend.app.task.celery import get_result_backend
     from backend.app.task.model import TaskExtended
-    from backend.core.conf import settings
+    from backend.tests.utils.db import sync_test_db_url
 
     # 用同步引擎直插 —— 这张表由 celery 写，没有创建接口；
     # conftest 那套 override_get_db 是异步生成器，同步用例里用不了
-    url = get_result_backend().removeprefix('db+').replace(
-        f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
-    )
+    url = sync_test_db_url()
     factory = sessionmaker(create_engine(url, future=True), expire_on_commit=False)
 
     task_id = f'pytest-{_uuid.uuid4()}'
     with factory() as db:
         db.execute(
             insert(TaskExtended.__table__).values(
-                task_id=task_id, status='SUCCESS', name='pytest.demo_task',
-                worker='pytest-worker', retries=2, queue='celery',
+                task_id=task_id,
+                status='SUCCESS',
+                name='pytest.demo_task',
+                worker='pytest-worker',
+                retries=2,
+                queue='celery',
             )
         )
         db.commit()
@@ -301,7 +309,8 @@ def test_quartz_syntax_is_rejected(client: TestClient, token_headers, uniq, expr
     Unix cron 表达不了它，给个 `0 0 28-31 * *` 的近似值等于偷换承诺。
     """
     r = client.post(
-        BASE, headers=token_headers,
+        BASE,
+        headers=token_headers,
         json={'name': uniq, 'task': 'maintenance.prune_logs', 'type': 1, 'crontab': expr},
     )
     assert r.status_code == 422, f'{why} 没被拦住：{r.text[:200]}'
@@ -326,26 +335,32 @@ def seeded_results():
     from sqlalchemy import create_engine, delete, insert
     from sqlalchemy.orm import sessionmaker
 
-    from backend.app.task.celery import get_result_backend
     from backend.app.task.model import TaskExtended
-    from backend.core.conf import settings
+    from backend.tests.utils.db import sync_test_db_url
     from backend.utils.timezone import timezone
 
-    url = get_result_backend().removeprefix('db+').replace(
-        f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
-    )
+    url = sync_test_db_url()
     factory = sessionmaker(create_engine(url, future=True), expire_on_commit=False)
 
     tag = f'pytest-range-{_uuid.uuid4().hex[:8]}'
     now = timezone.now().replace(microsecond=0)
     # 'h1' 落在**今天**，专门给「只给日期会丢掉最后一天」那条用例
-    marks = {'h1': now - timedelta(hours=1), 'd1': now - timedelta(days=1),
-             'd5': now - timedelta(days=5), 'd10': now - timedelta(days=10)}
+    marks = {
+        'h1': now - timedelta(hours=1),
+        'd1': now - timedelta(days=1),
+        'd5': now - timedelta(days=5),
+        'd10': now - timedelta(days=10),
+    }
     with factory() as db:
         for key, at in marks.items():
-            db.execute(insert(TaskExtended.__table__).values(
-                task_id=f'{tag}-{key}', status='SUCCESS', name=tag, date_done=at,
-            ))
+            db.execute(
+                insert(TaskExtended.__table__).values(
+                    task_id=f'{tag}-{key}',
+                    status='SUCCESS',
+                    name=tag,
+                    date_done=at,
+                )
+            )
         db.commit()
 
     yield {'tag': tag, 'now': now, 'marks': marks}
@@ -360,7 +375,8 @@ FMT = '%Y-%m-%d %H:%M:%S'
 
 def _query(client: TestClient, token_headers, tag: str, **params) -> list[dict]:
     r = client.get(
-        '/tasks/results', headers=token_headers,
+        '/tasks/results',
+        headers=token_headers,
         params={'name': tag, 'page': 1, 'size': 20, **params},
     )
     assert r.status_code == 200, r.text
@@ -385,7 +401,9 @@ def test_result_time_range_filters(client: TestClient, token_headers, seeded_res
     assert _keys(got) == {'d10'}, got
 
     got = _query(
-        client, token_headers, tag,
+        client,
+        token_headers,
+        tag,
         start_time=(now - timedelta(days=7)).strftime(FMT),
         end_time=(now - timedelta(days=3)).strftime(FMT),
     )
@@ -405,9 +423,7 @@ def test_range_is_inclusive_on_both_ends(client: TestClient, token_headers, seed
     assert _keys(got) == {'d5'}, f'闭区间没命中边界上的那条：{got}'
 
 
-def test_end_time_without_clock_silently_drops_the_last_day(
-    client: TestClient, token_headers, seeded_results
-):
+def test_end_time_without_clock_silently_drops_the_last_day(client: TestClient, token_headers, seeded_results):
     """🔴 这条把「只传日期」的后果钉住，防的是前端偷懒。
 
     `end_time=2026-08-22`（不带时分秒）会被 pydantic 解析成当天 **00:00:00**，
@@ -430,9 +446,7 @@ def test_end_time_without_clock_silently_drops_the_last_day(
     assert 'h1' in with_clock, f'补了时分秒也没查到今天的记录：{with_clock}'
     # 刚过午夜时 h1 会落到昨天，那时这条演示不成立，跳过
     if now.hour >= 1:
-        assert 'h1' not in date_only, (
-            f'只给日期居然命中了今天的记录 —— pydantic 的解析口径变了？{date_only}'
-        )
+        assert 'h1' not in date_only, f'只给日期居然命中了今天的记录 —— pydantic 的解析口径变了？{date_only}'
         assert with_clock > date_only, '只给日期没有丢掉任何东西，这条用例失去意义'
 
 
@@ -454,11 +468,7 @@ def test_every_schedule_in_db_points_at_a_registered_task(client: TestClient, to
     registered = set(client.get(f'{BASE}/meta', headers=token_headers).json()['data']['tasks'])
     rows = client.get(f'{BASE}/all', headers=token_headers).json()['data']
 
-    broken = [
-        f"「{r['name']}」→ {r['task']}"
-        for r in rows
-        if r['enabled'] and r['task'] not in registered
-    ]
+    broken = [f'「{r["name"]}」→ {r["task"]}' for r in rows if r['enabled'] and r['task'] not in registered]
     assert not broken, (
         '这些调度指向未注册的任务，会按时触发但什么都不执行：\n  '
         + '\n  '.join(broken)
@@ -480,11 +490,10 @@ def test_fresh_install_has_every_index_the_models_declare(client: TestClient, to
     ⚠️ 它查的是 **fba_test**（conftest 指过去的那个库），所以
     「改完模型忘了在测试库建索引」也会被它抓到。
     """
-    from sqlalchemy import create_engine, text
+    from sqlalchemy import create_engine, inspect
 
-    from backend.app.task.celery import get_result_backend
     from backend.common.model import MappedBase
-    from backend.core.conf import settings
+    from backend.tests.utils.db import sync_test_db_url
 
     watched = ['task_result', 'task_scheduler', 'sys_login_log', 'sys_opera_log']
     want: set[tuple[str, str]] = set()
@@ -492,20 +501,15 @@ def test_fresh_install_has_every_index_the_models_declare(client: TestClient, to
         table = MappedBase.metadata.tables[name]
         want.update((name, idx.name) for idx in table.indexes)
 
-    url = get_result_backend().removeprefix('db+').replace(
-        f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
-    )
+    url = sync_test_db_url()
     engine = create_engine(url, future=True)
     try:
-        with engine.connect() as conn:
-            have = {
-                (r[0], r[1])
-                for r in conn.execute(text(
-                    'SELECT t.name, i.name FROM sys.indexes i '
-                    'JOIN sys.tables t ON t.object_id = i.object_id '
-                    'WHERE i.name IS NOT NULL'
-                ))
-            }
+        # 🔴 用 Inspector，不要查 `sys.indexes` —— 那是 **SQL Server 专属**的系统目录表。
+        # 原来这里是一条裸 SQL，在 postgres 上直接 `relation "sys.indexes" does not exist`
+        # （实测：issue #5 第一次在 postgres 上跑 pytest 时炸出来）。这条测试断言的是
+        # 「模型声明的索引在库里存在」，和方言无关，实现也不该跟某一种方言绑死。
+        inspector = inspect(engine)
+        have = {(name, idx['name']) for name in watched for idx in inspector.get_indexes(name) if idx.get('name')}
     finally:
         engine.dispose()
 

--- a/apps/api/backend/app/task/tests/test_scheduler_timing.py
+++ b/apps/api/backend/app/task/tests/test_scheduler_timing.py
@@ -25,11 +25,11 @@ import pytest
 from sqlalchemy import create_engine, delete, select
 from sqlalchemy.orm import sessionmaker
 
-from backend.app.task.celery import celery_app, get_result_backend
+from backend.app.task.celery import celery_app
 from backend.app.task.model.scheduler import TaskScheduler
 from backend.app.task.utils import schedulers as sched_mod
 from backend.app.task.utils.schedulers import DatabaseScheduler
-from backend.core.conf import settings
+from backend.tests.utils.db import sync_test_db_url
 from backend.utils.timezone import timezone
 
 #: 间隔统一 60 秒 —— 远大于任何建连/查询抖动
@@ -43,9 +43,7 @@ def test_factory():
     `sync_db` 默认按 `DATABASE_SCHEMA` 连开发库 —— 测试必须改到 `_test` 库，
     否则这组用例会往你正在手测的库里插调度（而且 beat 真在跑的话会执行它）。
     """
-    url = get_result_backend().removeprefix('db+').replace(
-        f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
-    )
+    url = sync_test_db_url()
     engine = create_engine(url, pool_pre_ping=True, future=True)
     yield sessionmaker(engine, expire_on_commit=False)
     engine.dispose()
@@ -188,7 +186,9 @@ def test_disabled_schedule_never_fires(db):
 def test_expired_schedule_does_not_fire(db):
     """过了截止时间就不再触发。"""
     insert(
-        db, name='timing-已过期', last_run='overdue',
+        db,
+        name='timing-已过期',
+        last_run='overdue',
         expire_time=timezone.now() - timedelta(minutes=1),
     )
     s = CapturingScheduler(app=celery_app)
@@ -199,7 +199,9 @@ def test_expired_schedule_does_not_fire(db):
 def test_not_started_yet_does_not_fire(db):
     """还没到开始时间就不触发。"""
     insert(
-        db, name='timing-未开始', last_run='overdue',
+        db,
+        name='timing-未开始',
+        last_run='overdue',
         start_time=timezone.now() + timedelta(hours=1),
     )
     s = CapturingScheduler(app=celery_app)
@@ -217,7 +219,8 @@ def test_one_off_fires_only_once(db):
     # 把「上次触发」再拨回两分钟前 —— 时间上又到点了，只剩计数能拦住它
     with db() as sess:
         sess.execute(
-            TaskScheduler.__table__.update()
+            TaskScheduler.__table__
+            .update()
             .where(TaskScheduler.id == pk)
             .values(last_run_time=timezone.now() - timedelta(seconds=EVERY * 2))
         )
@@ -283,7 +286,8 @@ def test_one_off_survives_a_reload(db, monkeypatch):
     # 时间上重新到点，但触发计数应该已经落库了
     with db() as sess:
         sess.execute(
-            TaskScheduler.__table__.update()
+            TaskScheduler.__table__
+            .update()
             .where(TaskScheduler.id == pk)
             .values(last_run_time=timezone.now() - timedelta(seconds=EVERY * 2))
         )

--- a/apps/api/backend/tests/utils/db.py
+++ b/apps/api/backend/tests/utils/db.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio.session import AsyncSession
 
 from backend.database.db import create_database_async_engine, create_database_async_session, get_database_url
@@ -19,3 +20,29 @@ async def override_get_db_transaction() -> AsyncGenerator[AsyncSession, None]:
     """获取数据库会话"""
     async with async_test_db_session.begin() as session:
         yield session
+
+
+def sync_test_db_url() -> str:
+    """celery 结果后端那套**同步**驱动的 URL，指向测试库。
+
+    🔴 **不要用字符串替换把 `/fba` 改成 `/fba_test`。** 原来五处测试都写的是
+    `url.replace(f'/{SCHEMA}?', f'/{SCHEMA}_test?')` —— 它依赖库名后面紧跟一个
+    `?`，而只有 SQL Server 的结果后端 URL 才有查询串（`?driver=ODBC+Driver+18…`）：
+
+        sqlserver   db+mssql+pyodbc://…/fba?driver=…   ← 有 ?，替换成功
+        postgresql  db+postgresql+psycopg://…/fba      ← 没有 ?，**替换静默失效**
+        mysql       db+mysql+pymysql://…/fba           ← 同上
+
+    失效的后果不是报错，是这些测试**连到开发库**上去跑：往 `fba` 里塞测试数据、
+    再拿 `fba_test` 的结果去断言。实测（postgres 首次跑 pytest）：
+    `test_prune_logs.py::test_deletes_old_keeps_new` 造的日志进了 `fba`，
+    而清理任务（conftest 已把它指向测试库）在 `fba_test` 上删了 0 条，
+    断言 `2 == 1` 失败 —— 报错信息完全不提数据库连错了这件事。
+
+    改成让 SQLAlchemy 自己解析 URL 再换库名，和方言无关。
+    """
+    from backend.app.task.celery import get_result_backend
+    from backend.core.conf import settings
+
+    url = make_url(get_result_backend().removeprefix('db+'))
+    return url.set(database=f'{settings.DATABASE_SCHEMA}_test').render_as_string(hide_password=False)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
     container_name: fba_redis
     # 端口刻意用 6380 而不是默认的 6379：开发机上常常已经跑着一个本地 Redis，
     # 撞端口时 compose 只会报 bind 失败，不会告诉你是哪个进程占的
@@ -67,13 +67,19 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # 可选的 PostgreSQL 验证环境：代码层已支持（DataBaseType.postgresql），
-  # 但从未实测跑过。不进默认 `up -d`（会跟 mssql 一起起、误导成"两个都要"），
-  # 需要时显式 `docker compose -f docker-compose.dev.yml --profile postgresql up -d postgres`。
+  # 可选的 PostgreSQL 环境。⚠️ 这里原来写着「代码层已支持，但从未实测跑过」——
+  # 那句话从 issue #5 起作废：CI 有一个平行的 `pytest · PostgreSQL` job，
+  # 整套 pytest 在 postgres 上是绿的（当时也当场炸出三个 bug，见 apps/api/AGENTS.md
+  # 「pytest 现在在**两种方言**上跑」）。
+  #
+  # 不进默认 `up -d`（会跟 mssql 一起起、误导成"两个都要"），需要时显式：
+  #   docker compose -f docker-compose.dev.yml --profile postgresql up -d postgres
   # 验证完想换回 SQL Server 主线，把 apps/api/.env 的 DATABASE_TYPE 改回 sqlserver 即可，
   # 这个容器留着不影响默认流程。
   postgres:
-    image: postgres:16-alpine
+    # 钉 digest 的理由同上面的 mssql（issue #66）：浮动标签会让环境在没人改代码的
+    # 情况下漂移。升级时显式换这串，不要删掉它让标签重新浮动。
+    image: postgres:16-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685
     container_name: fba_postgres
     profiles: ["postgresql"]
     environment:


### PR DESCRIPTION
Closes #5。顺带做掉 #66 里 service 镜像那半（剩下三个 Dockerfile 基础镜像留给 #66）。

## 结论先放

**PostgreSQL 上 232 个测试全绿，SQL Server 上 232 个测试全绿。** 但这是修完三个 bug 之后的结果——第一次在 postgres 上跑 pytest 时，三个都在。

## 补 CI 的过程中现形的三个 bug

都是 issue 预言的那一类：「代码分支存在、但从没被任何自动化跑过」。

### ① 五处测试连的是**开发库**，不是测试库

```python
url = get_result_backend().removeprefix('db+').replace(
    f'/{settings.DATABASE_SCHEMA}?', f'/{settings.DATABASE_SCHEMA}_test?'
)
```

这个替换依赖库名后面紧跟一个 `?`，而只有 SQL Server 的结果后端 URL 带查询串：

| 方言 | 结果后端 URL | 替换 |
|---|---|---|
| sqlserver | `…/fba?driver=ODBC+Driver+18…` | ✅ |
| postgresql | `…/fba` | ❌ **静默失效** |
| mysql | `…/fba` | ❌ **静默失效** |

失效之后测试往 `fba` 里塞数据、拿 `fba_test` 的结果断言。实测表现是
`test_deletes_old_keeps_new` 报 `assert 2 == 1`——**报错信息一个字都不提数据库连错了**。

改成 `backend/tests/utils/db.py: sync_test_db_url()`，用 `make_url(...).set(database=...)`，与方言无关。5 处全换。

### ② 索引守卫直接查 SQL Server 的系统目录表

`test_fresh_install_has_every_index_the_models_declare` 里是一条裸 SQL：
`SELECT t.name, i.name FROM sys.indexes i JOIN sys.tables t …`。
postgres 上 `relation "sys.indexes" does not exist`。改用 `sqlalchemy.inspect(engine).get_indexes()`。

### ③ 迁移的容错写法，两种方言语义**相反**

`c0000000comments` 用裸 `contextlib.suppress(ProgrammingError)` 做「已经是目标状态就忽略」。实测：

| 方言 | 一条 DDL 失败之后 | 裸 suppress | SAVEPOINT |
|---|---|---|---|
| postgresql | 整个事务被置成 aborted | ❌ 连环 `InFailedSQLTransactionError` | ✅ |
| mssql | 事务照常可用 | ✅ | ❌ `Cannot roll back sa_savepoint_1...` |

要害是 **Python 层把异常吞掉，并不能让已经作废的事务活过来**。那份迁移原来的 docstring 写着「实测 SQL Server 在这里不会毒化事务」——对 mssql 成立，对 postgres 不成立，而当时只有 SQL Server 在 CI 里跑，所以这句话一直看着是对的。

现在按方言分支，并且离线 `--sql` 模式直接放行——不放行会打掉 #59 留下的
`test_migrations_compile_offline_for_every_supported_dialect`（我第一版就踩了这个，mssql 上当场红）。

## 关于 issue 里第一条诉求，结论要改一下

issue 建议加「`alembic upgrade head` 从 base 走到 head 不报错」的检查。**这条跑不通，而且不该跑通**，实测三条路都堵死：

- 空库直接升：基线刻意是空的（不含建表 DDL），`33ffb491b69f` 要往 `sys_role`/`sys_menu` 插种子行，表不存在 → 炸
- 先 `create_all` 再 stamp 基线：`9609aedfaf8d` 要 `CREATE TABLE sys_notification`，`create_all` 已经建过了 → 炸
- 离线 `--sql` 整条链：`d0000000usertz` 用运行期自省判断列存不存在，`MockConnection` 上 `NoInspectionAvailable` → 三种方言都炸

新库的正路是 `fba init`（create_all + 种子 + stamp head），迁移链只对基线之后的增量负责。这条已经写进 `apps/api/AGENTS.md`，免得下一个人再推一遍同样的假设。

**能守的那部分守住了**：新 job 里多一步「空库跑 `alembic upgrade c0000000comments`」——8 条 ALTER 全部命中不存在的表，正好把容错分支整条走一遍。那是迁移链上唯一会故意让语句失败再吞掉的地方，平时在 CI 里一次都不会执行（测试库是 create_all + stamp head 的）。

## 新 job

`pytest · PostgreSQL`，结构和 `test-backend` 一一对应：建库 → reset_test_db → upgrade head → 容错分支守卫 → pytest。比 SQL Server 那个快得多（不用装 ODBC 驱动，postgres 容器几秒就绪）。

主线仍然是 SQL Server，这个是第二条腿不是取代。

## 顺带（#66 的一半）

新加的 `postgres:16-alpine` 和已有的三处 `redis:7-alpine` 都按 digest 钉死——同一份文件半钉半浮比全浮更容易误导。dev 编排里 postgres profile 那句「代码层已支持，但从未实测跑过」也作废了，一并改掉。

#66 剩下的是 `node:22-bookworm-slim` / `nginx:1.27-alpine` / `ghcr.io/astral-sh/uv:python3.13-bookworm-slim` 三个 Dockerfile 基础镜像。

## 验证

- SQL Server：232 passed（重建测试库 + upgrade head + 全量 pytest）
- PostgreSQL：232 passed（同一套流程，本地 PG 16.2）
- 空库 `upgrade c0000000comments`：两种方言都成功并停在正确的 revision
- `uvx ruff@0.16.4 check` 通过；`pnpm ctx:check` 错误 0

⚠️ 那三个测试文件里有 163 行是 `ruff format` 的重排——它们**改动前就不合格**，而 pre-commit 钩子会自动改，与其让它悄悄混进来不如显式做掉。功能改动看别的文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)