### PR TITLE
build: 生产镜像的三个基础镜像钉到 digest，并去掉被 digest 架空的 ARG PY (#66)

### DIFF
--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -11,10 +11,35 @@
 #
 #     docker build -f apps/api/Dockerfile.prod -t fba-api apps/api
 #
-ARG PY=3.13
+# 🔴 **基础镜像钉 digest，Python 版本因此长在镜像引用里，不再有 `ARG PY`。**
+# 原来是 `ARG PY=3.13` + `FROM …:python${PY}-bookworm-slim`。digest 一钉，那个 ARG
+# 就成了摆设：`--build-arg PY=3.12` 看起来生效了，实际拉的还是下面这串 digest 指向的
+# 3.13 镜像——**改了参数、行为没变、也不报错**，比不给参数更坏。要升 Python 就把
+# 标签和 digest 一起换掉，一次显式提交。
+#
+# 为什么钉（issue #66）：浮动标签下，同一个 commit 在两个时间点构建出来的镜像
+# 底包可能已经不同，出问题时无法从 Dockerfile 回推当时用的是哪个版本。
+# 标签留着是给人读的，digest 才是真相。
+#
+# 要升级 / 换一个 digest（不需要能 `docker pull`，问 registry 就行）：
+#
+#     # ghcr.io（本文件这个）
+#     T=$(curl -fsS "https://ghcr.io/token?scope=repository:astral-sh/uv:pull&service=ghcr.io" \
+#          | sed -E 's/.*"token":"([^"]+)".*/\1/')
+#     curl -fsSI -H "Authorization: Bearer $T" \
+#       -H 'Accept: application/vnd.oci.image.index.v1+json' \
+#       https://ghcr.io/v2/astral-sh/uv/manifests/python3.13-bookworm-slim | grep -i docker-content-digest
+#
+#     # Docker Hub（apps/web/Dockerfile 的 node / nginx）把 auth 换成
+#     # https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull
+#     # 再问 https://registry-1.docker.io/v2/library/node/manifests/<tag>
+#
+# 换完拿新 digest 反查一次（`…/manifests/sha256:<新值>`），确认它真的存在、
+# 且清单里有 linux/amd64——digest 写错的表现是构建时 manifest unknown，
+# 而那时你已经在 main 上了（`build-images` 只在 main 的 push 上跑）。
 
 # ── 构建期：uv 按 lock 装依赖 ──────────────────────────────────────
-FROM ghcr.io/astral-sh/uv:python${PY}-bookworm-slim AS builder
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc g++ make python3-dev unixodbc-dev \
@@ -33,7 +58,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-default-groups --group server --no-install-project
 
 # ── 运行期 ─────────────────────────────────────────────────────────
-FROM ghcr.io/astral-sh/uv:python${PY}-bookworm-slim AS runtime
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim@sha256:531f855bda2c73cd6ef67d56b733b357cea384185b3022bd09f05e002cd144ca AS runtime
 
 # 🔴 msodbcsql18 是必须的，上游那份 Dockerfile 没有这一段。
 # 应用走 `mssql+aioodbc`，celery 的 result backend 走 `mssql+pyodbc`，

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -13,7 +13,9 @@
 # 所以保留 workspace 的原始目录结构，整仓 COPY。代价只是构建阶段镜像大一点，
 # 多阶段之后丢弃，运行镜像里只有 dist + nginx。
 
-FROM node:22-bookworm-slim AS builder
+# 钉 digest 的理由见 apps/api/Dockerfile.prod 顶部（issue #66）：
+# 标签给人读，digest 是真相；升级时两者一起换，一次显式提交。
+FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS builder
 RUN corepack enable && corepack prepare pnpm@11.21.0 --activate
 WORKDIR /repo
 
@@ -42,7 +44,7 @@ ARG VITE_API_BASE=""
 RUN printf 'VITE_API_BASE=%s\n' "$VITE_API_BASE" > apps/web/.env.production \
  && pnpm --filter web build
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 AS runtime
 ENV TZ=Asia/Shanghai
 COPY --from=builder /repo/apps/web/dist /usr/share/nginx/html
 COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Closes #66 的第 2 项（生产镜像基础镜像）。第 1 项（SQL Server 服务镜像）早就在 #71 做完了；同类但 issue 没列的 `postgres` / `redis` 服务镜像在 #92 里一并钉了。

## 改了什么

| 文件 | 之前 | 之后 |
|---|---|---|
| `apps/api/Dockerfile.prod` ×2 | `ghcr.io/astral-sh/uv:python${PY}-bookworm-slim` | `…:python3.13-bookworm-slim@sha256:531f855b…` |
| `apps/web/Dockerfile` | `node:22-bookworm-slim` | `…@sha256:83f487e0…` |
| `apps/web/Dockerfile` | `nginx:1.27-alpine` | `…@sha256:65645c7b…` |

标签保留是给人读的，digest 才是真相——和 `mcr.microsoft.com/mssql/server:2022-latest@sha256:…` 那处写法一致。

## 顺带删掉 `ARG PY=3.13`

digest 一钉，这个 ARG 就成了摆设：`--build-arg PY=3.12` **看起来生效了**，实际拉的还是 digest 指向的 3.13 镜像——改了参数、行为没变、还不报错，比压根不提供这个参数更坏。Python 版本现在长在镜像引用里，要升就把标签和 digest 一起换，一次显式提交。

确认过全仓没有别处传这个 build-arg（`docker-compose.prod.yml` 和 ci.yml 里的 build-args 都是 `VITE_API_BASE`）。

## digest 是怎么来的、怎么验的

本机 docker daemon 到 `docker.io` 不通（这台机器的已知情况），所以没走 `docker pull`，直接问 registry API：

1. 用 token + `Accept: …image.index.v1+json` 取 `Docker-Content-Digest`
2. **拿到的 digest 再反查一次**（`…/manifests/sha256:<值>`），确认它真的存在、且清单里有 `linux/amd64`
3. node / nginx 两个在**第二个独立加速器**上又取了一遍，digest 与第一个一致

uv 那个是 ghcr.io，本机 `docker manifest inspect` 能直接按 digest 校验，已通过。

Dockerfile 顶部记了完整的重新解析命令，下次升级不用再翻这个 PR。

## ⚠️ 残留风险

`build-images` 只在 **main 的 push** 上跑，所以 digest 写错的第一现场是**合并之后**（表现为 `manifest unknown`）。这条也写进 Dockerfile 注释了。

合并后看一眼那个 job 就能确认。如果想把这个窗口关掉，可以让 PR 也跑一次 `push: false` 的构建——用现成的 `cache-from: type=gha` 大部分层能命中缓存，但会给每个 PR 加构建时间，这次没做，要的话单开一条。

## 没动的

- `docker-compose.dev.yml` 的 `rabbitmq:3.13.7-management`：已经钉到具体 patch 版本，不是跨版本浮动那一类，而且只在 profile 里、不进生产
- `apps/api/Dockerfile` 和 `apps/api/docker-compose.yml`：**上游 FBA 的原件**，仓库明确说了「保留是为了对照上游，不要拿它部署」，钉了反而制造无谓的分叉

🤖 Generated with [Claude Code](https://claude.com/claude-code)